### PR TITLE
refactor: creating a prop for name on FormRadio

### DIFF
--- a/example/components/FormRadioDemo.tsx
+++ b/example/components/FormRadioDemo.tsx
@@ -13,10 +13,9 @@ export const FormRadioDemo = () => {
       <FormRadio
         id="single-1"
         value={value}
-        selected={true}
         label="Single Radio 1 label text"
+        name="group1"
         inputProps={{
-          name: 'group1',
           onChange: handleChange,
         }}
       />
@@ -24,8 +23,8 @@ export const FormRadioDemo = () => {
         id="single-2"
         value={value}
         label="Single Radio 2 label text"
+        name="group1"
         inputProps={{
-          name: 'group1',
           onChange: handleChange,
         }}
       />

--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -12,6 +12,11 @@ type VisuallyHidden = {
   classes?: string;
 };
 
+export enum ErrorPosition {
+  TOP = 'top',
+  BOTTOM = 'bottom',
+}
+
 export type ErrorMessageProps = {
   /**
    * error message
@@ -65,6 +70,61 @@ export type LegendProps = {
   headingClasses?: string;
 };
 
+export type FormInputProps = {
+  /**
+   * input name
+   **/
+  name: string;
+  /**
+   * input type
+   **/
+  type: string;
+  /**
+   * input value
+   **/
+  value: any;
+  /**
+   * pass the validation rules(please refer to forgJS) and the message you want to display
+   **/
+  validation?: { rule: any; message: string } | any;
+  /**
+   * allow to customise the input with all the properites needed
+   **/
+  inputProps?: any;
+  /**
+   * allow to customise the error message with all the properites needed
+   **/
+  errorProps?: any;
+  /**
+   * generic parameter to pass whatever element before the input
+   **/
+  prefix?: any;
+  /**
+   * generic parameter to pass whatever element after the input
+   **/
+  suffix?: any;
+  /**
+   * function that will trigger all the time there's a change in the input
+   **/
+  onChange: (event: React.FormEvent<HTMLInputElement>) => void;
+  /**
+   * function that will check if is vald or not based on the validation rules
+   **/
+  isValid?: (valid: boolean) => void;
+  /**
+   * error message
+   **/
+  errorMessage?: any;
+  /**
+   * error position - top or bottom
+   **/
+  errorPosition?: ErrorPosition;
+  /**
+   * input ariaLabel
+   **/
+  ariaLabel?: string;
+};
+
 export type FormRadioProps = {
   /**
    * radio label
@@ -110,6 +170,10 @@ export type FormRadioProps = {
    * allows for customisation of the radio label with all the properites needed
    */
   labelProps?: any;
+  /**
+   * radio name
+   */
+  name?: string;
   /**
    * specifies whether the radio should be selected
    */

--- a/src/formGroup/FormGroup.tsx
+++ b/src/formGroup/FormGroup.tsx
@@ -119,7 +119,8 @@ export const FormGroup = ({
         <FormRadio
           key={`${id}_${index.toString()}`}
           {...item}
-          inputProps={{ ...inputProps, ...item.inputProps, name, onChange }}
+          name={name}
+          inputProps={{ ...inputProps, ...item.inputProps, onChange }}
           itemProps={{ ...itemProps, ...item.itemProps }}
           labelProps={{ ...labelProps, ...item.labelProps }}
         />

--- a/src/formInput/FormInput.tsx
+++ b/src/formInput/FormInput.tsx
@@ -1,65 +1,6 @@
 import React from 'react';
 import { useValidationOnChange, Roles } from '../common';
-
-type FormInputProps = {
-  /**
-   * input name
-   **/
-  name: string;
-  /**
-   * input type
-   **/
-  type: string;
-  /**
-   * input value
-   **/
-  value: any;
-  /**
-   * pass the validation rules(please refer to forgJS) and the message you want to display
-   **/
-  validation?: { rule: any; message: string } | any;
-  /**
-   * allow to customise the input with all the properites needed
-   **/
-  inputProps?: any;
-  /**
-   * allow to customise the error message with all the properites needed
-   **/
-  errorProps?: any;
-  /**
-   * generic parameter to pass whatever element before the input
-   **/
-  prefix?: any;
-  /**
-   * generic parameter to pass whatever element after the input
-   **/
-  suffix?: any;
-  /**
-   * function that will trigger all the time there's a change in the input
-   **/
-  onChange: (event: React.FormEvent<HTMLInputElement>) => void;
-  /**
-   * function that will check if is vald or not based on the validation rules
-   **/
-  isValid?: (valid: boolean) => void;
-  /**
-   * error message
-   **/
-  errorMessage?: any;
-  /**
-   * error position - top or bottom
-   **/
-  errorPosition?: ErrorPosition;
-  /**
-   * input ariaLabel
-   **/
-  ariaLabel?: string;
-};
-
-export enum ErrorPosition {
-  TOP = 'top',
-  BOTTOM = 'bottom',
-}
+import { ErrorPosition, FormInputProps } from '../common/components';
 
 export const FormInput = ({
   name,

--- a/src/formInput/__tests__/FormInput.test.tsx
+++ b/src/formInput/__tests__/FormInput.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { FormInput, ErrorPosition } from '../FormInput';
+import { FormInput } from '../FormInput';
+import { ErrorPosition } from '../../common/components';
 import userEvent from '@testing-library/user-event';
 
 const DummyComponent = ({ pos }: any) => {

--- a/src/formInput/index.ts
+++ b/src/formInput/index.ts
@@ -1,2 +1,2 @@
-export { FormInput, ErrorPosition } from './FormInput';
+export { FormInput } from './FormInput';
 export { FormInputMasked } from './FormInputMasked';

--- a/src/formRadio/FormRadio.tsx
+++ b/src/formRadio/FormRadio.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Roles } from '../common';
 import { Hint, FormRadioProps } from '../common/components';
 
@@ -14,6 +15,7 @@ export const FormRadio = ({
   inputProps,
   itemProps,
   labelProps,
+  name,
   selected,
 }: FormRadioProps) => (
   <div {...itemProps} role={Roles.formRadio}>
@@ -21,7 +23,8 @@ export const FormRadio = ({
       id={id}
       type="radio"
       value={value}
-      aria-label={ariaLabel || inputProps.name}
+      name={name}
+      aria-label={ariaLabel || name}
       aria-describedby={ariaDescribedBy || ''}
       aria-labelledby={ariaLabelledBy || labelProps ? labelProps.id : ''}
       disabled={disabled}
@@ -34,3 +37,7 @@ export const FormRadio = ({
     {hint && <Hint {...hint} />}
   </div>
 );
+
+FormRadio.propTypes = {
+  name: PropTypes.string.isRequired,
+};

--- a/src/formRadio/README.md
+++ b/src/formRadio/README.md
@@ -13,6 +13,7 @@ An example with all the available properties is:
 ```js
 <FormRadio
   label='radio-label'
+  name='radio-name'
   value={value}
   ariaLabel='aria-label'
   ariaDescribedBy='aria-described-by'
@@ -26,7 +27,6 @@ An example with all the available properties is:
   id='radio-id'
   inputProps={{
     className: 'class-name',
-    name: 'radio-name',
     onChange: handleChange
   }}
   itemProps={{
@@ -45,7 +45,7 @@ the available properties are:
 
 | Property             | Type                                               | Default | Required  | Description                                                           |
 | -------------------- | -------------------------------------------------- | ------- | --------- | --------------------------------------------------------------------- |
-| **label**            | string                                             | null    | **false** | label of the radio                                                    |
+| **label**            | string                                             | null    | **true**  | label of the radio                                                    |
 | **value**            | string                                             | null    | **true**  | value of the radio                                                    |
 | **ariaLabel**        | string                                             | null    | **false** | aria-label of the radio                                               |
 | **ariaDescribedBy**  | string                                             | null    | **false** | aria-described-by of the radio                                        |
@@ -55,4 +55,5 @@ the available properties are:
 | **inputProps**       | <any>                                              | null    | **false** | allows for customisation of the inputs with all the properites needed |
 | **itemProps**        | <any>                                              | null    | **false** | allows for customisation of the container with properties needed      |
 | **labelProps**       | <any>                                              | null    | **false** | allows for customisation of the label with all the properites needed  |
+| **name**             | string                                             | null    | **false** | name of the radio                                                     |
 | **selected**         | boolean                                            | null    | **false** | default checked of the radio                                          |

--- a/src/formRadio/__test__/FormRadio.test.tsx
+++ b/src/formRadio/__test__/FormRadio.test.tsx
@@ -7,12 +7,7 @@ import { FormRadio } from '../FormRadio';
 describe('FormRadio', () => {
   it('should render a radio', () => {
     render(
-      <FormRadio
-        id="myId"
-        value="choice 1"
-        label="my label"
-        inputProps={{ name: 'group1' }}
-      />
+      <FormRadio id="myId" value="choice 1" label="my label" name="group 1" />
     );
 
     expect(screen.getByRole('form-radio')).toBeInTheDocument();
@@ -20,12 +15,7 @@ describe('FormRadio', () => {
 
   it('should render a radio with a label', () => {
     render(
-      <FormRadio
-        id="myId"
-        value="choice 1"
-        label="my label"
-        inputProps={{ name: 'group1' }}
-      />
+      <FormRadio id="myId" value="choice 1" label="my label" name="group1" />
     );
 
     expect(screen.getByLabelText('my label')).toBeInTheDocument();
@@ -33,26 +23,17 @@ describe('FormRadio', () => {
 
   it('should render a radio with a value', () => {
     render(
-      <FormRadio
-        id="myId"
-        value="choice 1"
-        label="my label"
-        inputProps={{ name: 'group1' }}
-      />
+      <FormRadio id="myId" value="choice 1" label="my label" name="group1" />
     );
 
     expect(screen.getByLabelText('my label').getAttribute('value')).toBe(
       'choice 1'
     );
   });
+
   it('should render a radio with aria label match name if unspecified', () => {
     render(
-      <FormRadio
-        id="myId"
-        value="choice 1"
-        label="my label"
-        inputProps={{ name: 'group1' }}
-      />
+      <FormRadio id="myId" value="choice 1" label="my label" name="group1" />
     );
 
     expect(screen.getByLabelText('my label').getAttribute('aria-label')).toBe(
@@ -62,12 +43,7 @@ describe('FormRadio', () => {
 
   it('should render a radio with an id', () => {
     const { container } = render(
-      <FormRadio
-        id="myId"
-        value="choice 1"
-        label="my label"
-        inputProps={{ name: 'group1' }}
-      />
+      <FormRadio id="myId" value="choice 1" label="my label" name="group1" />
     );
 
     expect(container.querySelector('#myId')).toBeInTheDocument();
@@ -81,7 +57,8 @@ describe('FormRadio', () => {
         id="myId"
         value="choice 1"
         label="my label"
-        inputProps={{ name: 'group1', onChange: handleChange }}
+        name="group1"
+        inputProps={{ onChange: handleChange }}
       />
     );
 
@@ -94,12 +71,7 @@ describe('FormRadio', () => {
     const handleChange = jest.fn();
 
     render(
-      <FormRadio
-        id="myId"
-        value="choice 1"
-        label="my label"
-        inputProps={{ name: 'group1' }}
-      />
+      <FormRadio id="myId" value="choice 1" label="my label" name="group1" />
     );
 
     fireEvent['click'](screen.getByLabelText('my label'));
@@ -116,7 +88,8 @@ describe('FormRadio', () => {
         value="choice 1"
         label="my label"
         selected={true}
-        inputProps={{ name: 'group1', onChange: handleChange }}
+        name="group1"
+        inputProps={{ onChange: handleChange }}
       />
     );
     const container: HTMLElement = screen.getByRole('form-radio');
@@ -134,8 +107,9 @@ describe('FormRadio', () => {
         id="myId"
         value="choice 1"
         label="my label"
+        name="group1"
         disabled={true}
-        inputProps={{ name: 'group1', onChange: handleChange }}
+        inputProps={{ onChange: handleChange }}
       />
     );
     const container: HTMLElement = screen.getByRole('form-radio');
@@ -155,7 +129,7 @@ describe('FormRadio', () => {
           id: 'my-hint',
           text: 'my hint',
         }}
-        inputProps={{ name: 'group1' }}
+        name="group1"
         ariaDescribedBy="my-hint-item-hint"
       />
     );

--- a/stories/5.FormRadioExplanation.stories.mdx
+++ b/stories/5.FormRadioExplanation.stories.mdx
@@ -31,7 +31,6 @@ An example with all the available properties is:
   id='radio-id'
   inputProps={{
     className: 'class-name',
-    name: 'radio-name',
     onChange: handleChange
   }}
   itemProps={{
@@ -40,6 +39,7 @@ An example with all the available properties is:
   labelProps={{
     style: {display: 'flex'}
   }}
+  name='radio-name'
   selected={true}
 />
 ```

--- a/stories/6.FormRadio.stories.mdx
+++ b/stories/6.FormRadio.stories.mdx
@@ -11,11 +11,9 @@ import "./style.css";
       return (
         <FormRadio
           label="text example"
+          name="group1"
           value="value"
           id="radio-1"
-          inputProps={{
-            name: "group1"
-          }}
         />
       );
     }}

--- a/stories/7.FormRadioStyled.stories.mdx
+++ b/stories/7.FormRadioStyled.stories.mdx
@@ -26,12 +26,12 @@ In this section we're using the formRadio component providing the GovUk style pa
             }}
             inputProps={{
               className: "govuk-radios__input",
-              name: "changed-name",
               onChange: handleChange
             }}
             itemProps={{
               className: "govuk-radios__item"
             }}
+            name="changed-name"
           />
           <FormRadio
             id="changed-name"
@@ -42,12 +42,12 @@ In this section we're using the formRadio component providing the GovUk style pa
             }}
             inputProps={{
               className: "govuk-radios__input",
-              name: "changed-name",
               onChange: handleChange
             }}
             itemProps={{
               className: "govuk-radios__item"
             }}
+            name="changed-name"
           />
         </div>
       )
@@ -72,12 +72,12 @@ In this section we're using the formRadio component providing the GovUk style pa
             }}
             inputProps={{
               className: "govuk-radios__input",
-              name: "changed-country",
               onChange: handleChange
             }}
             itemProps={{
               className: "govuk-radios__item"
             }}
+            name="changed-country"
           />
           <FormRadio
             id="changed-country"
@@ -88,12 +88,12 @@ In this section we're using the formRadio component providing the GovUk style pa
             }}
             inputProps={{
               className: "govuk-radios__input",
-              name: "changed-country",
               onChange: handleChange
             }}
             itemProps={{
               className: "govuk-radios__item"
             }}
+            name="changed-country"
           />
           <FormRadio
             id="changed-country"
@@ -104,12 +104,12 @@ In this section we're using the formRadio component providing the GovUk style pa
             }}
             inputProps={{
               className: "govuk-radios__input",
-              name: "changed-country",
               onChange: handleChange
             }}
             itemProps={{
               className: "govuk-radios__item"
             }}
+            name="changed-country"
           />
           <FormRadio
             id="changed-country"
@@ -120,12 +120,12 @@ In this section we're using the formRadio component providing the GovUk style pa
             }}
             inputProps={{
               className: "govuk-radios__input",
-              name: "changed-country",
               onChange: handleChange
             }}
             itemProps={{
               className: "govuk-radios__item"
             }}
+            name="changed-country"
           />
         </div>
       )
@@ -150,12 +150,12 @@ In this section we're using the formRadio component providing the GovUk style pa
             }}
             inputProps={{
               className: "govuk-radios__input",
-              name: "changed-name-disabled",
               onChange: handleChange
             }}
             itemProps={{
               className: "govuk-radios__item"
             }}
+            name="changed-name-disabled"
           />
           <FormRadio
             id="changed-name-disabled"
@@ -166,12 +166,12 @@ In this section we're using the formRadio component providing the GovUk style pa
             }}
             inputProps={{
               className: "govuk-radios__input",
-              name: "changed-name-disabled",
               onChange: handleChange
             }}
             itemProps={{
               className: "govuk-radios__item"
             }}
+            name="changed-name-disabled"
           />
           <FormRadio
             id="changed-name-disabled"
@@ -182,13 +182,13 @@ In this section we're using the formRadio component providing the GovUk style pa
             }}
             inputProps={{
               className: "govuk-radios__input",
-              name: "changed-name-disabled",
               onChange: handleChange
             }}
             itemProps={{
               className: "govuk-radios__item"
             }}
             disabled={true}
+            name="changed-name-disabled"
           />
         </div>
       )
@@ -213,13 +213,13 @@ In this section we're using the formRadio component providing the GovUk style pa
             }}
             inputProps={{
               className: "govuk-radios__input",
-              name: "changed-name-preselected",
               onChange: handleChange
             }}
             itemProps={{
               className: "govuk-radios__item"
             }}
             selected={true}
+            name="changed-name-preselected"
           />
           <FormRadio
             id="changed-name-preselected"
@@ -230,12 +230,12 @@ In this section we're using the formRadio component providing the GovUk style pa
             }}
             inputProps={{
               className: "govuk-radios__input",
-              name: "changed-name-preselected",
               onChange: handleChange
             }}
             itemProps={{
               className: "govuk-radios__item"
             }}
+            name="changed-name-preselected"
           />
         </div>
       )
@@ -260,7 +260,6 @@ In this section we're using the formRadio component providing the GovUk style pa
             }}
             inputProps={{
               className: "govuk-radios__input",
-              name: "changed-name-with-hint",
               onChange: handleChange
             }}
             itemProps={{
@@ -271,6 +270,7 @@ In this section we're using the formRadio component providing the GovUk style pa
               classes: "govuk-hint govuk-radios__hint",
               id: "sign-in-item-hint"
             }}
+            name="changed-name-with-hint"
           />
           <FormRadio
             id="changed-name-with-hint-2"
@@ -281,7 +281,6 @@ In this section we're using the formRadio component providing the GovUk style pa
             }}
             inputProps={{
               className: "govuk-radios__input",
-              name: "changed-name-with-hint",
               onChange: handleChange
             }}
             itemProps={{
@@ -292,6 +291,7 @@ In this section we're using the formRadio component providing the GovUk style pa
               classes: "govuk-hint govuk-radios__hint",
               id: "sign-in-2-item-hint"
             }}
+            name="changed-name-with-hint"
           />
         </div>
       )


### PR DESCRIPTION
Name is now available on `FormRadio` as a prop
- FormRadio should be given a name if not react will provide a warning