### PR TITLE
fix: allow to pass extra properties in the generated component

### DIFF
--- a/src/generatePresentationalComponent/__test__/generateComponent.test.ts
+++ b/src/generatePresentationalComponent/__test__/generateComponent.test.ts
@@ -9,7 +9,7 @@ export const Label = (props: any) => {
   const branded: any = brandedComponentStyle(jsonStyle.label);
 
   return (
-    <DynamicComponent dynamicStyle={branded.style} tag={branded.tag}>
+    <DynamicComponent dynamicStyle={branded.style} tag={branded.tag} {...props}>
       {props.children}
     </DynamicComponent>
   );

--- a/src/generatePresentationalComponent/generateComponent.ts
+++ b/src/generatePresentationalComponent/generateComponent.ts
@@ -9,7 +9,7 @@ export const {{componentName}} = (props: any) => {
   const branded: any = brandedComponentStyle(jsonStyle.{{jsonPath}});
 
   return (
-    <DynamicComponent dynamicStyle={branded.style} tag={branded.tag}>
+    <DynamicComponent dynamicStyle={branded.style} tag={branded.tag} {...props}>
       {props.children}
     </DynamicComponent>
   );


### PR DESCRIPTION
fix the following raised bug: https://github.com/Capgemini/dcx-react-library/issues/75