### PR TITLE
feat: trigger forminput error on submit

### DIFF
--- a/src/formInput/FormInput.tsx
+++ b/src/formInput/FormInput.tsx
@@ -55,9 +55,9 @@ type FormInputProps = {
    **/
   ariaLabel?: string;
   /**
-   * it will allow you to do not display the error message on load
+   * you can trigger to display an error without interact with the component
    */
-  displayErrorOnLoad?: boolean;
+  displayError?: boolean;
 };
 
 export enum ErrorPosition {
@@ -79,26 +79,30 @@ export const FormInput = ({
   errorMessage,
   errorPosition,
   ariaLabel,
-  displayErrorOnLoad = false,
+  displayError = false,
 }: FormInputProps) => {
   const { validity, onValueChange } = useValidationOnChange(validation, value);
-  const [showErrorOnLoad, setShowErrorOnLoad] = React.useState<boolean>(
-    displayErrorOnLoad
-  );
+
+  const [showError, setShowError] = React.useState<boolean>(displayError);
+
   React.useEffect(() => {
     if (isValid && validity)
-      isValid(validity.valid, showErrorOnLoad && !validity.valid);
-  }, [validity?.valid, showErrorOnLoad]);
+      isValid(validity.valid, showError && !validity.valid);
+  }, [validity?.valid, showError]);
+
+  React.useEffect(() => {
+    displayError ? setShowError(true) : setShowError(false);
+  }, [displayError]);
 
   const handleChange = (event: React.FormEvent<HTMLInputElement>) => {
-    setShowErrorOnLoad(true);
+    setShowError(true);
     if (onValueChange) onValueChange(event);
     onChange(event);
   };
 
   const ErrorMessage = () => (
     <div {...errorProps}>
-      {validity && !validity.valid && showErrorOnLoad ? (
+      {validity && !validity.valid && showError ? (
         <div role={Roles.error} {...errorMessage}>
           {validity.message}
         </div>

--- a/src/formInput/__tests__/FormInput.test.tsx
+++ b/src/formInput/__tests__/FormInput.test.tsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom';
 import { ErrorPosition, FormInput } from '../FormInput';
 import userEvent from '@testing-library/user-event';
 
-const DummyComponent = ({ pos, displayErrorOnLoad = true }: any) => {
+const DummyComponent = ({ pos, displayError = false }: any) => {
   const [value, setValue] = React.useState('');
   const [isValid, setValid] = React.useState<boolean | string>('');
   const handleInputChange = (evt: any) => setValue(evt.currentTarget.value);
@@ -20,7 +20,7 @@ const DummyComponent = ({ pos, displayErrorOnLoad = true }: any) => {
         errorPosition={pos}
         onChange={handleInputChange}
         isValid={handleValidity}
-        displayErrorOnLoad={displayErrorOnLoad}
+        displayError={displayError}
         errorProps={{
           'data-testid': 'error-container',
         }}
@@ -36,6 +36,42 @@ const DummyComponent = ({ pos, displayErrorOnLoad = true }: any) => {
         }}
       />
       <label data-testid="check-validity">{isValid.toString()}</label>
+    </>
+  );
+};
+
+const DummyComponentTriggerError = () => {
+  const handleInputChange = jest.fn();
+  const [displayError, setDisplayError] = React.useState(false);
+
+  const handleClick = () => {
+    setDisplayError(true);
+  };
+
+  return (
+    <>
+      <FormInput
+        name="password"
+        type="text"
+        value=""
+        onChange={handleInputChange}
+        displayError={displayError}
+        errorPosition={ErrorPosition.BOTTOM}
+        errorProps={{
+          'data-testid': 'error-container',
+        }}
+        validation={{
+          rule: {
+            type: 'password',
+            minLength: 8,
+            uppercase: 1,
+            numbers: 1,
+            matchesOneOf: ['@', '_', '-', '.', '!'],
+          },
+          message: 'is invalid',
+        }}
+      />
+      <button onClick={handleClick}>submit</button>
     </>
   );
 };
@@ -132,12 +168,18 @@ describe('FormInput', () => {
     expect(validLabel.innerHTML).toBe('true');
   });
 
-  it('should not display the error message on load', () => {
-    render(
-      <DummyComponent pos={ErrorPosition.BOTTOM} displayErrorOnLoad={false} />
-    );
+  it('should display the error message on load', () => {
+    render(<DummyComponent pos={ErrorPosition.BOTTOM} displayError={true} />);
+    expect(screen.getByRole('error')).toContainHTML('is invalid');
+  });
+
+  it('should display the error message without interact with the component', () => {
+    render(<DummyComponentTriggerError />);
     expect(() => screen.getByText('is invalid')).toThrow(
       'Unable to find an element'
     );
+    const button = screen.getByRole('button');
+    userEvent.click(button);
+    expect(screen.getByRole('error')).toContainHTML('is invalid');
   });
 });

--- a/stories/2.FormInput.stories.mdx
+++ b/stories/2.FormInput.stories.mdx
@@ -60,7 +60,90 @@ import "./style.css";
                 Post
                 </div>
             }
-            />
+        />
+      );
+    }}
+    />
+  </Story>
+</Canvas>
+
+### An example of 'un-styled' Input with error triggered by a button
+You can trigger the error message without interact with the input. In the following example the button will decide to display or not the error message
+```js
+const [displayError, setDisplayError] = React.useState(false);
+const handleClick = () => {
+    setDisplayError(true);
+}
+<FormInput
+     ...
+     displayError={displayError}
+ /> 
+ <button onClick={handleClick}>submit</button>   
+```
+<Canvas>
+  <Story name="un-styled-trigger-validity">
+       {() => {
+        const [value, setValue] = React.useState('');
+        const [displayError, setDisplayError] = React.useState(false);
+        const handleChange = event => {
+            setValue(event.currentTarget.value);
+        }
+        const handleValidity = valid => {
+            console.log(valid);
+        }
+        const handleClick = () => {
+            setDisplayError(true);
+        }
+      return (
+          <>
+        <FormInput
+            name="password"
+            type="text"
+            value={value}
+            displayError={displayError}
+            onChange={handleChange}
+            isValid={handleValidity}
+            inputProps={{
+                placeholder: 'enter your password',
+            }}
+            errorProps={{
+                style: {fontSize: '10px', color: 'red', fontWeight: 'bold'},
+            }}
+            validation={{
+                rule: {
+                type: 'password',
+                minLength: 8,
+                uppercase: 1,
+                numbers: 1,
+                matchesOneOf: ['@', '_', '-', '.', '!'],
+                },
+                message:
+                'your password need to be min 8 chars 1 Uppercase, 1 Number and one special character',
+            }}
+            errorPosition="bottom"
+            prefix={
+                <div
+                style={{
+                    border: '1px solid #d2d2d2',
+                    padding: '5px',
+                }}
+                >
+                Pre
+                </div>
+            }
+            suffix={
+                <div
+                style={{
+                    border: '1px solid #d2d2d2',
+                    padding: '5px',
+                }}
+                >
+                Post
+                </div>
+            }
+        />
+        <button onClick={handleClick}>submit</button>
+        </>
       );
     }}
     />


### PR DESCRIPTION
This Pr fix the following ticket: https://github.com/Capgemini/dcx-react-library/issues/98

```
Some form have the submit button enable bu default and they allow you to click without interact with all the components inside.
The forminput should display an error message (if not valid) as soon the button is pressed
```