### PR TITLE
feat: allow to pass props and default values

### DIFF
--- a/src/generatePresentationalComponent/__test__/generateComponent.test.ts
+++ b/src/generatePresentationalComponent/__test__/generateComponent.test.ts
@@ -1,70 +1,118 @@
 import * as componentGenerator from '../generateComponent';
 const mock = require('mock-fs');
 
-const outputFile = `
-import React from 'react';
+const outputFile = `import React from 'react';
 import { DynamicComponent, brandedComponentStyle } from 'dcx-react-library';
 import jsonStyle from '../stories/typographyDemo/input/label.json';
-export const Label = (props: any) => {
+export const Label = ({...props}: any) => {
   const branded: any = brandedComponentStyle(jsonStyle.label);
-
+  const newProps = {...props};
   return (
-    <DynamicComponent dynamicStyle={branded.style} tag={branded.tag} {...props}>
+    <DynamicComponent dynamicStyle={branded.style} tag={branded.tag}  {...newProps}>
       {props.children}
     </DynamicComponent>
   );
 };`;
 
-const outputCamelFile = `
-import React from 'react';
+const outputCamelFile = `import React from 'react';
 import { DynamicComponent, brandedComponentStyle } from 'dcx-react-library';
 import jsonStyle from '../stories/typographyDemo/headingOne/headingOne.json';
-export const HeadingOne = (props: any) => {
+export const HeadingOne = ({...props}: any) => {
   const branded: any = brandedComponentStyle(jsonStyle.headingOne);
-
+  const newProps = {...props};
   return (
-    <DynamicComponent dynamicStyle={branded.style} tag={branded.tag} {...props}>
+    <DynamicComponent dynamicStyle={branded.style} tag={branded.tag}  {...newProps}>
       {props.children}
     </DynamicComponent>
   );
 };`;
 
-const outputCamelFile2 = `
-import React from 'react';
+const linkFile = `import React from 'react';
 import { DynamicComponent, brandedComponentStyle } from 'dcx-react-library';
-import jsonStyle from '../stories/typographyDemo/headingOne/heading-one.json';
-export const HeadingOne = (props: any) => {
-  const branded: any = brandedComponentStyle(jsonStyle.heading-one);
-
+import jsonStyle from '../stories/typographyDemo/link/link.json';
+export const Link = ({href,text,ariaLabel,...props}: any) => {
+  const branded: any = brandedComponentStyle(jsonStyle.link);
+  const newProps = {href,text,ariaLabel,...props};
   return (
-    <DynamicComponent dynamicStyle={branded.style} tag={branded.tag} {...props}>
+    <DynamicComponent dynamicStyle={branded.style} tag={branded.tag} target="_blank" rel="noopener noreferrer"  {...newProps}>
       {props.children}
     </DynamicComponent>
   );
 };`;
 
-const inputFile = {
-  'label.json': {
+const label = {
+  label: {
     tag: 'label',
     color: {
-      value: '#6a737c',
+      value: 'red',
     },
-    fontWeight: {
-      value: 'bold',
+    display: {
+      value: 'inline-block',
     },
-    fontSize: {
-      value: '12px',
+    'max-width': {
+      value: '100%',
+    },
+    'margin-bottom': {
+      value: '5px',
+    },
+    'font-weight': {
+      value: '700',
     },
   },
 };
 
-const fileStructure = {
-  stories: {
-    typographyDemo: {
-      input: inputFile,
-      output: {
-        'Label.tsx': outputFile,
-      },
+const headingOne = {
+  headingOne: {
+    tag: 'h1',
+    color: {
+      value: 'red',
+    },
+    display: {
+      value: 'inline-block',
+    },
+    'max-width': {
+      value: '100%',
+    },
+    'margin-bottom': {
+      value: '5px',
+    },
+    'font-weight': {
+      value: '700',
+    },
+  },
+};
+
+const link = {
+  link: {
+    tag: 'a',
+    props: ['href', 'text', 'ariaLabel'],
+    defaultValues: {
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    },
+    color: {
+      value: '#337ab7',
+    },
+    display: {
+      value: 'inline-block',
+    },
+    'max-width': {
+      value: '100%',
+    },
+    'font-weight': {
+      value: '400',
+    },
+    'font-size': {
+      value: '12px',
+    },
+    'line-height': {
+      value: 1.5,
+    },
+    cursor: {
+      value: 'pointer',
+    },
+    padding: {
+      value: '5px 10px',
     },
   },
 };
@@ -81,7 +129,17 @@ beforeEach(() => {
   ];
 
   generateComponent = jest.spyOn(componentGenerator, 'generateComponent');
-  mock(fileStructure);
+
+  mock({
+    'stories/typographyDemo/input/label.json': `${JSON.stringify(label)}`,
+    'stories/typographyDemo/headingOne/headingOne.json': `${JSON.stringify(
+      headingOne
+    )}`,
+    'stories/typographyDemo/headingOne/heading-one.json': `${JSON.stringify(
+      headingOne
+    )}`,
+    'stories/typographyDemo/link/link.json': `${JSON.stringify(link)}`,
+  });
 });
 
 afterAll(() => {
@@ -148,12 +206,12 @@ describe('generateComponent', () => {
     expect(component).toContain(outputCamelFile);
   });
 
-  it('should camelCase the name', () => {
+  it('should allow to pass props and defaultValues', () => {
     const component = componentGenerator.generateComponentTemplate(
-      'stories/typographyDemo/headingOne/',
-      'heading-one.json',
+      'stories/typographyDemo/link/',
+      'link.json',
       'components/'
     );
-    expect(component).toContain(outputCamelFile2);
+    expect(component).toContain(linkFile);
   });
 });

--- a/src/generatePresentationalComponent/generateComponent.ts
+++ b/src/generatePresentationalComponent/generateComponent.ts
@@ -5,23 +5,40 @@ const template = `
 import React from 'react';
 import { DynamicComponent, brandedComponentStyle } from 'dcx-react-library';
 import jsonStyle from '{{inputFolder}}/{{fileName}}';
-export const {{componentName}} = (props: any) => {
+export const {{componentName}} = ({{{userProps}}...props}: any) => {
   const branded: any = brandedComponentStyle(jsonStyle.{{jsonPath}});
-
+  const newProps = {{{userProps}}...props};
   return (
-    <DynamicComponent dynamicStyle={branded.style} tag={branded.tag} {...props}>
+    <DynamicComponent dynamicStyle={branded.style} tag={branded.tag} {{defaultValues}} {...newProps}>
       {props.children}
     </DynamicComponent>
   );
-};
-`;
+};`;
 
-/**
- * It will prepare the new React component from the given template
- * @param {*} inputFolder
- * @param {*} inputFile
- * @returns
- */
+export const replaceUserProps = (inputFile: string, data: any) => {
+  let userProps = '';
+  const jsonPath = inputFile.replace('.json', '');
+  const parseFile = JSON.parse(data);
+  if (parseFile[jsonPath].props) {
+    userProps = parseFile[jsonPath].props.join(',').concat(',');
+  }
+  return userProps;
+};
+
+export const replaceDefaultValues = (inputFile: string, data: any) => {
+  let values = '';
+  const jsonPath = inputFile.replace('.json', '');
+  const parseFile = JSON.parse(data);
+  if (parseFile[jsonPath].defaultValues) {
+    const def = parseFile[jsonPath].defaultValues;
+
+    Object.keys(def).forEach(function(key) {
+      values = values.concat(`${key}="${def[key]}" `);
+    });
+  }
+  return values;
+};
+
 export const generateComponentTemplate = (
   inputFolder: string,
   inputFile: string,
@@ -31,13 +48,21 @@ export const generateComponentTemplate = (
     pascalCase: true,
     preserveConsecutiveUppercase: true,
   });
+
   const jsonPath = inputFile.replace('.json', '');
   const relativePath = path.relative(outputFolder, inputFolder);
+  const fullPath = path.join(inputFolder, inputFile);
+  const data = fs.readFileSync(fullPath, 'utf8');
+  const userProps = replaceUserProps(inputFile, data);
+  const defaultValues = replaceDefaultValues(inputFile, data);
+
   return template
     .replace('{{inputFolder}}/{{fileName}}', `${relativePath}/${inputFile}`)
     .replace('{{jsonPath}}', jsonPath)
     .replace(/{{componentName}}/g, componentName)
-    .replace(/\/\//g, '/');
+    .replace(/{{userProps}}/g, userProps)
+    .replace('{{defaultValues}}', defaultValues)
+    .replace(/(^[ \t]*\n)/gm, '');
 };
 
 /**

--- a/stories/0.presentationalComponents.stories.mdx
+++ b/stories/0.presentationalComponents.stories.mdx
@@ -14,6 +14,7 @@ Example:
 - Subtitle
 - Label
 - Hint
+- Link
 
 These components do not perform any action but they store a common style that is usable in the application. `dcx-react-library` create this component for you.
 
@@ -41,7 +42,35 @@ under `component-template` you can place all the `.json` template that will desc
 
 For example:
 
+- label.json
+
+the label component will be a `div` element with the css properties:
+
+```css
+color: 'black'
+font-weight: 'bold'
+font-size: '32px'
+```
+
+```json
+{
+  "title": {
+    "color": {
+      "value": "black"
+    },
+    "fontWeight": {
+      "value": "bold"
+    },
+    "fontSize": {
+      "value": "32px"
+    }
+  }
+}
+```
+
 - title.json
+
+The title will be an `H1` element (we defined "tag": "h1") and the same css properties
 
 ```json
 {
@@ -60,10 +89,53 @@ For example:
 }
 ```
 
+- link.json
+
+the Link component will be an `a` element ("tag": "a") will have default properties ("target": "\_blank" and "rel": "noopener noreferrer") and will require 3 props ("href", "text", "ariaLabel").
+
+```json
+{
+  "link": {
+    "tag": "a",
+    "props": ["href", "text", "ariaLabel"],
+    "defaultValues": {
+      "target": "_blank",
+      "rel": "noopener noreferrer"
+    },
+    "color": {
+      "value": "#337ab7"
+    },
+    "display": {
+      "value": "inline-block"
+    },
+    "max-width": {
+      "value": "100%"
+    },
+    "font-weight": {
+      "value": "400"
+    },
+    "font-size": {
+      "value": "12px"
+    },
+    "line-height": {
+      "value": 1.5
+    },
+    "cursor": {
+      "value": "pointer"
+    },
+    "padding": {
+      "value": "5px 10px"
+    }
+  }
+}
+```
+
 These json files will contains:
 
 - the name of the component. This name will need to match the name of the file. For example if the file is called `title.json` the key for the object will be `title` (**mandatory**);
 - the tag. It will specify the tag attribute of the component (**optional** if not specified will be a div);
+- the defaultValues. It will allow to pass static values to the component (**optional**);
+- the props. Will allow to use the component passing extra properties (**optional**);
 - the css properties are **camel-case** (all the css attributes are valid).
 
 In the title example we will create a new component as `h2` and will have a black color, with `font-weight:bold` and `font-size:20px`.


### PR DESCRIPTION
PR related to the follow ticket: https://github.com/Capgemini/dcx-react-library/issues/96

The following PR will allow you to pass props and defaultValues to generate components.
ex:
```json
{
  "link": {
    "tag": "a",
    "props": ["href", "text", "ariaLabel"],     <------
    "defaultValues": {                                    <------
      "target": "_blank",
      "rel": "noopener noreferrer"
    },
    "color": {
      "value": "#337ab7"
    }
  }
}```