### PR TITLE
feat: adding an enchacement to allow customisation of the heading within legend component

### DIFF
--- a/example/components/FormRadioDemo.tsx
+++ b/example/components/FormRadioDemo.tsx
@@ -60,7 +60,9 @@ export const FormRadioDemo = () => {
         }}
         legend={{
           text: 'Basic Group Radios',
-          isHeading: true,
+          heading: {
+            priority: 4,
+          },
         }}
         onChange={handleChange}
       />

--- a/src/common/components/Legend.tsx
+++ b/src/common/components/Legend.tsx
@@ -1,13 +1,23 @@
 import React from 'react';
 import { LegendProps } from '../components';
 
-export const Legend = ({
-  text,
-  classes,
-  isHeading = false,
-  headingClasses,
-}: LegendProps) => (
-  <legend className={classes}>
-    {isHeading ? <h1 className={headingClasses}>{text}</h1> : text}
+const LOWEST_HEADING: number = 6;
+const HIGHEST_HEADING: number = 1;
+
+export const Legend = ({ text, className, heading }: LegendProps) => (
+  <legend className={className}>
+    {heading
+      ? React.createElement(
+          `h${
+            heading &&
+            heading.priority >= HIGHEST_HEADING &&
+            heading.priority <= LOWEST_HEADING
+              ? heading.priority
+              : 1
+          }`,
+          { className: heading.className },
+          text
+        )
+      : text}
   </legend>
 );

--- a/src/common/components/__tests__/Legend.test.tsx
+++ b/src/common/components/__tests__/Legend.test.tsx
@@ -5,7 +5,9 @@ import { Legend } from '../Legend';
 
 describe('Legend', () => {
   it('will render a legend', () => {
-    render(<Legend text="Have you changed your name?" classes="my-classes" />);
+    render(
+      <Legend text="Have you changed your name?" className="my-className" />
+    );
 
     expect(screen.getByText('Have you changed your name?')).toBeInTheDocument();
   });
@@ -14,8 +16,10 @@ describe('Legend', () => {
     const { container } = render(
       <Legend
         text="Have you changed your name?"
-        classes="my-classes"
-        isHeading={true}
+        className="my-className"
+        heading={{
+          priority: 1,
+        }}
       />
     );
 
@@ -29,13 +33,63 @@ describe('Legend', () => {
     const { container } = render(
       <Legend
         text="Have you changed your name?"
-        classes="my-classes"
-        isHeading={true}
-        headingClasses="my-classes"
+        className="my-className"
+        heading={{
+          priority: 1,
+          className: 'my-className',
+        }}
       />
     );
 
     expect(container.querySelector('h1')).toBeInTheDocument();
-    expect(container.querySelector('h1')?.classList).toContain('my-classes');
+    expect(container.querySelector('h1')?.classList).toContain('my-className');
+  });
+
+  it('will render a legend with a customised heading of priority 2', () => {
+    const { container } = render(
+      <Legend
+        text="Have you changed your name?"
+        className="my-className"
+        heading={{
+          priority: 2,
+          className: 'my-className',
+        }}
+      />
+    );
+
+    expect(container.querySelector('h2')).toBeInTheDocument();
+    expect(container.querySelector('h2')?.classList).toContain('my-className');
+  });
+
+  it('will render a legend with a customised heading of priority 1 where given an incorrect priority', () => {
+    const { container } = render(
+      <Legend
+        text="Have you changed your name?"
+        className="my-className"
+        heading={{
+          priority: 8,
+          className: 'my-className',
+        }}
+      />
+    );
+
+    expect(container.querySelector('h1')).toBeInTheDocument();
+    expect(container.querySelector('h1')?.classList).toContain('my-className');
+  });
+
+  it('will render a legend with a customised heading of priority 1 where given an sub 1 priority', () => {
+    const { container } = render(
+      <Legend
+        text="Have you changed your name?"
+        className="my-className"
+        heading={{
+          priority: 0,
+          className: 'my-className',
+        }}
+      />
+    );
+
+    expect(container.querySelector('h1')).toBeInTheDocument();
+    expect(container.querySelector('h1')?.classList).toContain('my-className');
   });
 });

--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -13,6 +13,17 @@ type VisuallyHidden = {
   classes?: string;
 };
 
+type HeadingProps = {
+  /**
+   * heading priority
+   */
+  priority: number;
+  /**
+   * heading class names to customise heading
+   **/
+  className?: string;
+};
+
 export type ConditionalInputProps = {
   /**
    * conditional input name
@@ -165,13 +176,9 @@ export type LegendProps = {
   /**
    * legend class names to customise legend
    **/
-  classes?: string;
+  className?: string;
   /**
-   * states whether legend should be a heading
-   **/
-  isHeading?: boolean;
-  /**
-   * heading class names to customise heading
-   **/
-  headingClasses?: string;
+   * legend heading
+   */
+  heading?: HeadingProps;
 };

--- a/src/formGroup/__test__/FormGroup.test.tsx
+++ b/src/formGroup/__test__/FormGroup.test.tsx
@@ -15,7 +15,9 @@ describe('FormGroup', () => {
         name=""
         legend={{
           text: 'Have you changed your name?',
-          isHeading: true,
+          heading: {
+            priority: 1,
+          },
         }}
         items={[
           {
@@ -76,7 +78,9 @@ describe('FormGroup', () => {
         name=""
         legend={{
           text: 'Have you changed your name?',
-          isHeading: true,
+          heading: {
+            priority: 1,
+          },
         }}
         items={[
           {
@@ -106,7 +110,9 @@ describe('FormGroup', () => {
         name=""
         legend={{
           text: 'Have you changed your name?',
-          isHeading: true,
+          heading: {
+            priority: 1,
+          },
         }}
         items={[
           {
@@ -139,7 +145,9 @@ describe('FormGroup', () => {
         name=""
         legend={{
           text: 'Have you changed your name?',
-          isHeading: true,
+          heading: {
+            priority: 1,
+          },
         }}
         error={{
           text: 'oops!! we have an error',
@@ -175,7 +183,9 @@ describe('FormGroup', () => {
         name=""
         legend={{
           text: 'Have you changed your name?',
-          isHeading: true,
+          heading: {
+            priority: 1,
+          },
         }}
         items={[
           {
@@ -205,7 +215,9 @@ describe('FormGroup', () => {
         name="group1"
         legend={{
           text: 'Have you changed your name?',
-          isHeading: true,
+          heading: {
+            priority: 1,
+          },
         }}
         items={[
           {
@@ -241,7 +253,9 @@ describe('FormGroup', () => {
         name="group1"
         legend={{
           text: 'Have you changed your name?',
-          isHeading: true,
+          heading: {
+            priority: 1,
+          },
         }}
         items={[
           {
@@ -275,7 +289,9 @@ describe('FormGroup', () => {
         name=""
         legend={{
           text: 'Have you changed your name?',
-          isHeading: true,
+          heading: {
+            priority: 1,
+          },
         }}
         items={[
           {
@@ -309,7 +325,9 @@ describe('FormGroup', () => {
         name=""
         legend={{
           text: 'Have you changed your name?',
-          isHeading: true,
+          heading: {
+            priority: 1,
+          },
         }}
         items={[
           {
@@ -344,7 +362,9 @@ describe('FormGroup', () => {
         name=""
         legend={{
           text: 'Have you changed your name?',
-          isHeading: true,
+          heading: {
+            priority: 1,
+          },
         }}
         items={[
           {
@@ -392,7 +412,9 @@ describe('FormGroup', () => {
         }}
         legend={{
           text: 'Have you changed your name?',
-          isHeading: true,
+          heading: {
+            priority: 1,
+          },
         }}
         items={[
           {
@@ -454,7 +476,9 @@ describe('FormGroup', () => {
         name=""
         legend={{
           text: 'Have you changed your name?',
-          isHeading: true,
+          heading: {
+            priority: 1,
+          },
         }}
         items={[
           {
@@ -489,7 +513,9 @@ describe('FormGroup', () => {
         name=""
         legend={{
           text: 'Have you changed your name?',
-          isHeading: true,
+          heading: {
+            priority: 1,
+          },
         }}
         items={[
           {

--- a/stories/12.FormGroupExplanation.stories.mdx
+++ b/stories/12.FormGroupExplanation.stories.mdx
@@ -108,19 +108,21 @@ An example with all the available properties is:
        }
     }}
     fieldsetClasses='fieldset classes'
-    hint={
+    hint={{
         text: 'hint-text',
         classes: 'class names',
         id: 'hint-id'
-    }
+    }}
     id='id'
     itemsClasses='class names for the group items'
-    legend={
-        text='heading',
-        classes='legend classes',
-        isHeading=true,
-        headingClasses='heading classes'
-    }
+    legend={{
+        text: 'heading',
+        className: 'legend classes',
+        heading: {
+            priority: 2,
+            className: 'heading class name'
+        }
+    }}
     onChange={handleChange}
 />
 ```

--- a/stories/13.FormGroup.stories.mdx
+++ b/stories/13.FormGroup.stories.mdx
@@ -7,27 +7,28 @@ import "./style.css";
 ### An example of 'un-styled' FormGroup of radio buttons
 <Canvas>
   <Story name="un-styled">
-      {() => {
-        const handleChange = event => {
-          // handle change
-        }
-        return (
-            <FormGroup
-                name='name-of-group'
-                items={[
-                    {
-                        label: 'item-label',
-                        value: 'yes',
-                        onChange: (e) => handleChange(e)
-                    },
-                    {
-                        label: 'item-label',
-                        value: 'no',
-                        onChange: (e) => handleChange(e)
-                    }
-                ]}
-            />
-        );
+    {() => {
+      return (
+        <FormGroup
+            name='name-of-group'
+            legend={{
+              text: 'Heading text customisable by a given priority of type number between 1 to 6 (inclusive)',
+              heading: {
+                priority: 2
+              }
+            }}
+            items={[
+              {
+                label: 'item-label',
+                value: 'yes'
+              },
+              {
+                label: 'item-label',
+                value: 'no'
+              }
+            ]}
+        />
+      );
     }}
     />
   </Story>
@@ -35,22 +36,18 @@ import "./style.css";
 
 <Canvas>
   <Story name="error">
-      {() => {
-        const handleChange = event => {
-          // handle change
-        }
-        return (
-            <FormGroup
-                name='name-of-group'
-                items={[
-                    {
-                        label: 'item-label',
-                        value: 'yes',
-                        onChange: (e) => handleChange(e)
-                    }
-                ]}
-            />
-        );
+    {() => {
+      return (
+        <FormGroup
+          name='name-of-group'
+          items={[
+            {
+              label: 'item-label',
+              value: 'yes'
+            }
+          ]}
+        />
+      );
     }}
     />
   </Story>

--- a/stories/14.FormGroupStyled.stories.mdx
+++ b/stories/14.FormGroupStyled.stories.mdx
@@ -11,9 +11,6 @@ In this section we are using the FormGroup component providing the GOV.UK Design
 <Canvas>
     <Story name="inline">
         {() => {
-            const handleChange = (event) => {
-                // handle change
-            }
             return (
                 <FormGroup
                     name="change-name"
@@ -29,14 +26,12 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                     items={[{
                         label: "Yes",
                         value: "yes",
-                        id: "change-name",
-                        onChange: (e) => handleChange(e)
+                        id: "change-name"
                     },
                     {
                         label: "No",
                         value: "no",
-                        id: "change-name-2",
-                        onChange: (e) => handleChange(e)                     
+                        id: "change-name-2"                    
                     }]}
                     ariaDescribedBy="changed-name-hint"
                     groupClasses="govuk-form-group"
@@ -49,9 +44,11 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                     itemsClasses="govuk-radios govuk-radios--inline"
                     legend={{
                         text: "Have you changed your name?",
-                        classes: "govuk-fieldset__legend govuk-fieldset__legend--l",
-                        isHeading: true,
-                        headingClasses: "govuk-fieldset__heading"
+                        className: "govuk-fieldset__legend govuk-fieldset__legend--l",
+                        heading: {
+                            priority: 1,
+                            className: "govuk-fieldset__heading"
+                        }
                     }}
                 />
             )
@@ -62,9 +59,6 @@ In this section we are using the FormGroup component providing the GOV.UK Design
 <Canvas>
     <Story name="titled">
         {() => {
-            const handleChange = (event) => {
-                // handle change
-            }
             return (
                 <FormGroup
                     name="change-name-2"
@@ -80,14 +74,12 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                     items={[{
                         label: "Yes",
                         value: "yes",
-                        id: "change-name-2-1",
-                        onChange: (e) => handleChange(e)
+                        id: "change-name-2-1"
                     },
                     {
                         label: "No",
                         value: "no",
-                        id: "change-name-2-2",
-                        onChange: (e) => handleChange(e)                   
+                        id: "change-name-2-2"                 
                     }]}
                     ariaDescribedBy="changed-name-hint"
                     groupClasses="govuk-form-group"
@@ -100,9 +92,11 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                     itemsClasses="govuk-radios govuk-radios--inline"
                     legend={{
                         text: "Have you changed your name?",
-                        classes: "govuk-fieldset__legend govuk-fieldset__legend",
-                        isHeading: true,
-                        headingClasses: "govuk-fieldset__heading"
+                        className: "govuk-fieldset__legend govuk-fieldset__legend",
+                        heading: {
+                            priority: 1,
+                            className: "govuk-fieldset__heading"
+                        }
                     }}
                 />
             )
@@ -113,9 +107,6 @@ In this section we are using the FormGroup component providing the GOV.UK Design
 <Canvas>
     <Story name="stacked">
         {() => {
-            const handleChange = (event) => {
-                // handle change
-            }
             return (
                 <FormGroup
                     name="where-do-you-live"
@@ -131,33 +122,29 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                     items={[{
                         label: "England",
                         value: "england",
-                        id: "where-do-you-live",
-                        onChange: (e) => handleChange(e)
+                        id: "where-do-you-live"
                     },
                     {
                         label: "Scotland",
                         value: "scotland",
-                        id: "where-do-you-live-2",
-                        onChange: (e) => handleChange(e)
+                        id: "where-do-you-live-2"
                     },
                     {
                         label: "Wales",
                         value: "wales",
-                        id: "where-do-you-live-3",
-                        onChange: (e) => handleChange(e)
+                        id: "where-do-you-live-3"
                     },
                     {
                         label: "Northern Ireland",
                         value: "northen-ireland",
-                        id: "where-do-you-live-4",
-                        onChange: (e) => handleChange(e)
+                        id: "where-do-you-live-4"
                     }]}
                     groupClasses="govuk-form-group"
                     fieldsetClasses="govuk-fieldset"
                     itemsClasses="govuk-radios"
                     legend={{
                         text: "Where do you live?",
-                        classes: "govuk-fieldset__legend govuk-fieldset__legend--l"
+                        className: "govuk-fieldset__legend govuk-fieldset__legend--l"
                     }}
                 />
             )
@@ -168,9 +155,6 @@ In this section we are using the FormGroup component providing the GOV.UK Design
 <Canvas>
     <Story name="items with hints">
         {() => {
-            const handleChange = (event) => {
-                // handle change
-            }
             return (
                 <FormGroup
                     name="sign-in"
@@ -192,8 +176,7 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                            classes: "govuk-hint govuk-radios__hint",
                            id: "sign-in-item-hint"
                         },
-                        ariaDescribedBy: "sign-in-item-hint",
-                        onChange: (e) => handleChange(e)
+                        ariaDescribedBy: "sign-in-item-hint"
                     },
                     {
                         label: "Sign in with GOV.UK Verify",
@@ -204,8 +187,7 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                            classes: "govuk-hint govuk-radios__hint",
                            id: "sign-in-2-item-hint"
                         },
-                        ariaDescribedBy: "sign-in-item-hint",
-                        onChange: (e) => handleChange(e)
+                        ariaDescribedBy: "sign-in-item-hint"
                     }]}
                     ariaDescribedBy="sign-in-hint"
                     groupClasses="govuk-form-group"
@@ -218,9 +200,11 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                     itemsClasses="govuk-radios"
                     legend={{
                         text: "How do you want to sign in?",
-                        classes: "govuk-fieldset__legend govuk-fieldset__legend--l",
-                        isHeading: true,
-                        headingClasses: "govuk-fieldset__heading"
+                        className: "govuk-fieldset__legend govuk-fieldset__legend--l",
+                        heading: {
+                            priority: 1,
+                            className: "govuk-fieldset__heading"
+                        }
                     }}
                 />
             )
@@ -231,9 +215,6 @@ In this section we are using the FormGroup component providing the GOV.UK Design
 <Canvas>
     <Story name="filter">
         {() => {
-            const handleChange = (event) => {
-                // handle change
-            }
             return (
                 <FormGroup
                     name="filter-change"
@@ -249,23 +230,23 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                     items={[{
                         label: "Monthly",
                         value: "month",
-                        id: "changed-name-month",
-                        onChange: (e) => handleChange(e)
+                        id: "changed-name-month"
                     },
                     {
                         label: "Yearly",
                         value: "year",
-                        id: "changed-name-year",
-                        onChange: (e) => handleChange(e)                    
+                        id: "changed-name-year"                   
                     }]}
                     groupClasses="govuk-radios govuk-radios--small"
                     fieldsetClasses="govuk-fieldset"
                     itemsClasses="govuk-radios govuk-radios--small"
                     legend={{
                         text: "Filter",
-                        classes: "govuk-fieldset__legend govuk-fieldset__legend--m",
-                        isHeading: true,
-                        headingClasses: "govuk-fieldset__heading"
+                        className: "govuk-fieldset__legend govuk-fieldset__legend--m",
+                        heading: {
+                            priority: 1,
+                            className: "govuk-fieldset__heading"
+                        }
                     }}
                 />
             )
@@ -276,9 +257,6 @@ In this section we are using the FormGroup component providing the GOV.UK Design
 <Canvas>
     <Story name="error message">
         {() => {
-            const handleChange = (event) => {
-                // handle change
-            }
             return (
                 <FormGroup
                     name="change-name-error"
@@ -294,14 +272,12 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                     items={[{
                         label: "Yes",
                         value: "yes",
-                        id: "change-name-yes-error",
-                        onChange: (e) => handleChange(e)
+                        id: "change-name-yes-error"
                     },
                     {
                         label: "No",
                         value: "no",
-                        id: "change-name-no-error",
-                        onChange: (e) => handleChange(e)                     
+                        id: "change-name-no-error"                     
                     }]}
                     ariaDescribedBy="changed-name-hint changed-name-error"
                     groupClasses="govuk-form-group govuk-form-group--error"
@@ -323,9 +299,11 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                     itemsClasses="govuk-radios govuk-radios--inline"
                     legend={{
                         text: "Have you changed your name?",
-                        classes: "govuk-fieldset__legend govuk-fieldset__legend--l",
-                        isHeading: true,
-                        headingClasses: "govuk-fieldset__heading"
+                        className: "govuk-fieldset__legend govuk-fieldset__legend--l",
+                        heading: {
+                            priority: 1,
+                            className: "govuk-fieldset__heading"
+                        }
                     }}
                 />
             )
@@ -336,9 +314,6 @@ In this section we are using the FormGroup component providing the GOV.UK Design
 <Canvas>
     <Story name="with a text divider">
         {() => {
-            const handleChange = (event) => {
-                // handle change
-            }
             return (
                 <FormGroup
                     name="where-do-you-live-divider"
@@ -354,26 +329,22 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                     items={[{
                         label: "England",
                         value: "england",
-                        id: "where-do-you-live-divider",
-                        onChange: (e) => handleChange(e)
+                        id: "where-do-you-live-divider"
                     },
                     {
                         label: "Scotland",
                         value: "scotland",
-                        id: "where-do-you-live-divider-2",
-                        onChange: (e) => handleChange(e)
+                        id: "where-do-you-live-divider-2"
                     },
                     {
                         label: "Wales",
                         value: "wales",
-                        id: "where-do-you-live-divider-3",
-                        onChange: (e) => handleChange(e)
+                        id: "where-do-you-live-divider-3"
                     },
                     {
                         label: "Northern Ireland",
                         value: "northen-ireland",
-                        id: "where-do-you-live-divider-4",
-                        onChange: (e) => handleChange(e)
+                        id: "where-do-you-live-divider-4"
                     },
                     {
                         className: "govuk-radios__divider",
@@ -382,8 +353,7 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                     {
                         label: "I am a British citizen living abroad",
                         value: "living-abroad",
-                        id: "where-do-you-live-divider-5",
-                        onChange: (e) => handleChange(e)
+                        id: "where-do-you-live-divider-5"
                     }
                     ]}
                     groupClasses="govuk-form-group"
@@ -391,7 +361,7 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                     itemsClasses="govuk-radios"
                     legend={{
                         text: "Where do you live?",
-                        classes: "govuk-fieldset__legend govuk-fieldset__legend--l"
+                        className: "govuk-fieldset__legend govuk-fieldset__legend--l"
                     }}
                 />
             )
@@ -402,9 +372,6 @@ In this section we are using the FormGroup component providing the GOV.UK Design
 <Canvas>
     <Story name="conditionally revealing content">
         {() => {
-            const handleChange = (event) => {
-                // handle change
-            }
             return (
                 <FormGroup
                     name="contact"
@@ -431,8 +398,7 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                             id: "conditional-contact",
                             inputClassName: "govuk-input govuk-!-width-one-third",
                             inputId: "contact-by-email"
-                        },
-                        onChange: (e) => handleChange(e)
+                        }
                     },
                     {
                         label: "Phone",
@@ -448,8 +414,7 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                             id: "conditional-contact-2",
                             inputClassName: "govuk-input govuk-!-width-one-third",
                             inputId: "contact-by-phone"
-                        },
-                        onChange: (e) => handleChange(e)
+                        }
                     },
                     {
                         label: "Text message",
@@ -465,8 +430,7 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                             id: "conditional-contact-3",
                             inputClassName: "govuk-input govuk-!-width-one-third",
                             inputId: "contact-by-text"
-                        },
-                        onChange: (e) => handleChange(e)
+                        }
                     }]}
                     ariaDescribedBy="contact-hint"
                     groupClasses="govuk-form-group"
@@ -479,9 +443,11 @@ In this section we are using the FormGroup component providing the GOV.UK Design
                     itemsClasses="govuk-radios govuk-radios--conditional"
                     legend={{
                         text: "How would you prefer to be contacted?",
-                        classes: "govuk-fieldset__legend govuk-fieldset__legend--l",
-                        isHeading: true,
-                        headingClasses: "govuk-fieldset__heading"
+                        className: "govuk-fieldset__legend govuk-fieldset__legend--l",
+                        heading: {
+                            priority: 1,
+                            className: "govuk-fieldset__heading"
+                        }
                     }}
                 />
             )


### PR DESCRIPTION
- FormGroup now allows users to provide a `priority: number` within heading that decides what kind of heading tag is added within the legend

```
type HeadingProps = {
  /**
   * heading priority
   */
  priority: number;
  /**
   * heading class names to customise heading
   **/
  className?: string;
};
``` 

```
 <FormGroup
            name='name-of-group'
            legend={{
              text: 'Heading text customisable by a given priority of type number between 1 to 6 (inclusive)',
              heading: {
                priority: 2
              }
            }}
            items={[
              {
                label: 'item-label',
                value: 'yes'
              },
              {
                label: 'item-label',
                value: 'no'
              }
            ]}
        />
      );
    }}
    />
  ```