### PR TITLE
feat: adding the option for checkbox and radio buttons to be nested

### DIFF
--- a/src/common/components/commonTypes.ts
+++ b/src/common/components/commonTypes.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 type VisuallyHidden = {
   /**
    * visually hidden text
@@ -126,19 +128,23 @@ export type FormRadioProps = {
   /**
    * allows for customisation of the radio input with all the properites needed
    */
-  inputProps?: any;
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   /**
    * allows for customisation of the radio input with all the properites needed
    */
-  itemProps?: any;
+  itemProps?: React.HTMLAttributes<HTMLDivElement>;
   /**
    * allows for customisation of the radio label with all the properites needed
    */
-  labelProps?: any;
+  labelProps?: React.LabelHTMLAttributes<HTMLLabelElement>;
   /**
    * radio name
    */
   name?: string;
+  /**
+   * renders a nested radio within a label tag
+   */
+  nested?: boolean;
   /**
    * specifies whether the radio should be selected
    */
@@ -197,15 +203,15 @@ export type FormCheckboxProps = {
   /**
    * allows for customisation of the checkbox input with all the properites needed
    **/
-  inputProps?: any;
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   /**
    * allows for customisation of the checkbox input with all the properites needed
    **/
-  itemProps?: any;
+  itemProps?: React.HTMLAttributes<HTMLDivElement>;
   /**
    * allows for customisation of the checkbox label with all the properites needed
    **/
-  labelProps?: any;
+  labelProps?: React.LabelHTMLAttributes<HTMLLabelElement>;
   /**
    * specifies whether the checkbox should be disabled
    */
@@ -218,6 +224,11 @@ export type FormCheckboxProps = {
    * checkbox conditionally input field
    */
   conditional?: ConditionalInputProps;
+  /**
+   * renders a nested checkbox within a label tag
+   */
+
+  nested?: boolean;
 };
 
 export type HintProps = {

--- a/src/formCheckbox/FormCheckbox.tsx
+++ b/src/formCheckbox/FormCheckbox.tsx
@@ -21,30 +21,46 @@ export const FormCheckbox = ({
   selected,
   hint,
   hintPosition = 'below',
+  nested,
 }: FormCheckboxProps) => {
   const conditionalReveal = (): boolean =>
     !_.isEmpty(conditional) && selected === true;
 
-  return (
-    <div {...itemProps}>
-      {hint && hintPosition === 'above' && <Hint {...hint} />}
-      <input
-        id={id}
-        type="checkbox"
-        name={name}
-        value={value}
-        aria-label={ariaLabel || name}
-        data-aria-controls={ariaDataControls}
-        aria-describedby={ariaDescribedBy}
-        aria-labelledby={ariaLabelledBy || labelProps ? labelProps.id : ''}
-        disabled={disabled}
-        defaultChecked={selected}
-        onChange={onChange}
-        {...inputProps}
-      />
+  const input: JSX.Element = (
+    <input
+      id={id}
+      type="checkbox"
+      name={name}
+      value={value}
+      aria-label={ariaLabel || name}
+      data-aria-controls={ariaDataControls}
+      aria-describedby={ariaDescribedBy}
+      aria-labelledby={ariaLabelledBy || labelProps?.id}
+      disabled={disabled}
+      defaultChecked={selected}
+      onChange={onChange}
+      {...inputProps}
+    />
+  );
+
+  const checkbox: JSX.Element = nested ? (
+    <label {...labelProps}>
+      {input}
+      {label}
+    </label>
+  ) : (
+    <>
+      {input}
       <label {...labelProps} htmlFor={id}>
         {label}
       </label>
+    </>
+  );
+
+  return (
+    <div {...itemProps}>
+      {hint && hintPosition === 'above' && <Hint {...hint} />}
+      {checkbox}
       {hint && hintPosition === 'below' && <Hint {...hint} />}
       {conditional !== undefined &&
         conditionalReveal() &&

--- a/src/formCheckbox/__test__/FormCheckbox.test.tsx
+++ b/src/formCheckbox/__test__/FormCheckbox.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, queryByAttribute } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import fireEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { FormCheckbox } from '../FormCheckbox';
@@ -23,6 +23,53 @@ describe('FormCheckbox', () => {
     );
   });
 
+  it('should render a checkbox with a sibling label', () => {
+    const handleChange = jest.fn();
+
+    const { container } = render(
+      <FormCheckbox
+        id="myId"
+        value="choice 1"
+        label="my label"
+        labelProps={{
+          id: 'my-label',
+        }}
+        name="group1"
+        onChange={handleChange}
+      />
+    );
+
+    const label: HTMLElement | null = container.querySelector('#my-label');
+
+    expect(screen.getByLabelText('my label')).toBeInTheDocument();
+    expect(container.querySelector('input[type=checkbox]')).not.toBeNull();
+    expect(label?.querySelector('input[type=checkbox]')).toBeNull();
+  });
+
+  it('should render a nested checkbox within a label', () => {
+    const { container } = render(
+      <FormCheckbox
+        id="myId"
+        value="choice 1"
+        label="my label"
+        labelProps={{
+          id: 'my-label',
+        }}
+        name="group1"
+        nested={true}
+        inputProps={{
+          id: 'my-checkbox',
+        }}
+      />
+    );
+
+    const label: HTMLElement | null = container.querySelector('#my-label');
+
+    expect(screen.getByLabelText('my label')).toBeInTheDocument();
+    expect(container.querySelector('input[type=checkbox]')).not.toBeNull();
+    expect(label?.querySelector('input[type=checkbox]')).not.toBeNull();
+  });
+
   it('should call on change', () => {
     const handleChange = jest.fn();
 
@@ -44,7 +91,7 @@ describe('FormCheckbox', () => {
   it('should set checkbox as checked if selected is added as a prop', () => {
     const handleChange = jest.fn();
 
-    render(
+    const { container } = render(
       <FormCheckbox
         id="myId"
         name="group1"
@@ -52,20 +99,19 @@ describe('FormCheckbox', () => {
         label="my label"
         selected={true}
         onChange={handleChange}
-        itemProps={{ 'data-testid': 'checkbox-container' }}
+        itemProps={{ id: 'checkbox-container' }}
       />
     );
-    const container: HTMLElement = screen.getByTestId('checkbox-container');
-    const getById = queryByAttribute.bind(null, 'id');
+    const checkbox: HTMLElement | null = container.querySelector('#myId');
 
-    expect(getById(container, 'myId')).toBeChecked();
-    expect(getById(container, 'myId')).not.toBeDisabled();
+    expect(checkbox).toBeChecked();
+    expect(checkbox).not.toBeDisabled();
   });
 
   it('should set checkbox as disabled if specified', () => {
     const handleChange = jest.fn();
 
-    render(
+    const { container } = render(
       <FormCheckbox
         id="myId"
         name="group1"
@@ -73,14 +119,14 @@ describe('FormCheckbox', () => {
         label="my label"
         disabled={true}
         onChange={handleChange}
-        itemProps={{ 'data-testid': 'checkbox-container' }}
+        itemProps={{ id: 'checkbox-container' }}
       />
     );
-    const container: HTMLElement = screen.getByTestId('checkbox-container');
-    const getById = queryByAttribute.bind(null, 'id');
 
-    expect(getById(container, 'myId')).not.toBeChecked();
-    expect(getById(container, 'myId')).toBeDisabled();
+    const checkbox: HTMLElement | null = container.querySelector('#myId');
+
+    expect(checkbox).not.toBeChecked();
+    expect(checkbox).toBeDisabled();
   });
 
   it('should render a checkbox with aria label match name if unspecified', () => {

--- a/src/formGroup/FormGroup.tsx
+++ b/src/formGroup/FormGroup.tsx
@@ -65,11 +65,11 @@ type FormGroupProps = {
   /**
    * form group input properties for all items
    */
-  inputProps?: any;
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   /**
    * form group item properties for all items
    */
-  itemProps?: any;
+  itemProps?: React.HTMLAttributes<HTMLDivElement>;
   /**
    * form group items class names
    */
@@ -77,7 +77,7 @@ type FormGroupProps = {
   /**
    * form group label properties for all items
    */
-  labelProps?: any;
+  labelProps?: React.LabelHTMLAttributes<HTMLLabelElement>;
   /**
    * form group legend properties
    */

--- a/src/formGroup/__test__/FormGroup.test.tsx
+++ b/src/formGroup/__test__/FormGroup.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import fireEvent from '@testing-library/user-event';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { FormGroup } from '../FormGroup';
 
@@ -342,7 +341,7 @@ describe('FormGroup', () => {
         items={[
           {
             inputProps: {
-              'data-testid': 'custom-item',
+              id: 'custom-item',
             },
             value: 'yes',
             label: 'Yes',
@@ -358,7 +357,7 @@ describe('FormGroup', () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId('custom-item'));
+    fireEvent.click(screen.getAllByRole('radio')[0]);
     expect(handleItemChange).toHaveBeenCalled();
   });
 
@@ -381,7 +380,7 @@ describe('FormGroup', () => {
         items={[
           {
             inputProps: {
-              'data-testid': 'custom-item',
+              id: 'custom-item',
             },
             value: 'one',
             label: 'One',
@@ -399,7 +398,7 @@ describe('FormGroup', () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId('custom-item'));
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
     expect(handleItemChange).toHaveBeenCalled();
   });
 
@@ -422,7 +421,7 @@ describe('FormGroup', () => {
         items={[
           {
             inputProps: {
-              'data-testid': 'custom-item',
+              id: 'custom-item',
             },
             value: 'yes',
             label: 'Yes',
@@ -436,7 +435,7 @@ describe('FormGroup', () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId('custom-item'));
+    fireEvent.click(screen.getAllByRole('radio')[0]);
     expect(handleItemChange).not.toHaveBeenCalled();
   });
 
@@ -459,7 +458,7 @@ describe('FormGroup', () => {
         items={[
           {
             inputProps: {
-              'data-testid': 'custom-item',
+              id: 'custom-item',
             },
             value: 'yes',
             label: 'Yes',
@@ -473,7 +472,7 @@ describe('FormGroup', () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId('custom-item'));
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
     expect(handleItemChange).not.toHaveBeenCalled();
   });
 
@@ -496,7 +495,7 @@ describe('FormGroup', () => {
         items={[
           {
             inputProps: {
-              'data-testid': 'custom-item',
+              id: 'custom-item',
             },
             value: 'yes',
             label: 'Yes',
@@ -511,7 +510,7 @@ describe('FormGroup', () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId('custom-item'));
+    fireEvent.click(screen.getAllByRole('radio')[0]);
     expect(handleChange).not.toHaveBeenCalled();
   });
 
@@ -534,7 +533,7 @@ describe('FormGroup', () => {
         items={[
           {
             inputProps: {
-              'data-testid': 'custom-item',
+              id: 'custom-item',
             },
             value: 'yes',
             label: 'Yes',
@@ -549,7 +548,7 @@ describe('FormGroup', () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId('custom-item'));
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
     expect(handleChange).not.toHaveBeenCalled();
   });
 
@@ -571,7 +570,7 @@ describe('FormGroup', () => {
         items={[
           {
             inputProps: {
-              'data-testid': 'custom-item',
+              id: 'custom-item',
             },
             value: 'yes',
             label: 'Yes',
@@ -588,7 +587,7 @@ describe('FormGroup', () => {
       />
     );
 
-    expect(screen.getByTestId('custom-item')).toBeChecked();
+    expect(screen.getAllByRole('radio')[0]).toBeChecked();
   });
 
   it('should render the first item of checkboxes as checked', () => {
@@ -609,7 +608,7 @@ describe('FormGroup', () => {
         items={[
           {
             inputProps: {
-              'data-testid': 'custom-item',
+              id: 'custom-item',
             },
             value: 'yes',
             label: 'Yes',
@@ -626,7 +625,7 @@ describe('FormGroup', () => {
       />
     );
 
-    expect(screen.getByTestId('custom-item')).toBeChecked();
+    expect(screen.getAllByRole('checkbox')[0]).toBeChecked();
   });
 
   it('should render the first item of radio buttons as disabled', () => {
@@ -647,7 +646,7 @@ describe('FormGroup', () => {
         items={[
           {
             inputProps: {
-              'data-testid': 'custom-item',
+              id: 'custom-item',
             },
             value: 'yes',
             label: 'Yes',
@@ -656,7 +655,7 @@ describe('FormGroup', () => {
           },
           {
             inputProps: {
-              'data-testid': 'custom-item-2',
+              id: 'custom-item-2',
             },
             value: 'no',
             label: 'No',
@@ -668,7 +667,7 @@ describe('FormGroup', () => {
       />
     );
 
-    expect(screen.getByTestId('custom-item-2')).toBeDisabled();
+    expect(screen.getAllByRole('radio')[1]).toBeDisabled();
   });
 
   it('should render the first item of checkboxes as disabled', () => {
@@ -689,7 +688,7 @@ describe('FormGroup', () => {
         items={[
           {
             inputProps: {
-              'data-testid': 'custom-item',
+              id: 'custom-item',
             },
             value: 'yes',
             label: 'Yes',
@@ -698,7 +697,7 @@ describe('FormGroup', () => {
           },
           {
             inputProps: {
-              'data-testid': 'custom-item-2',
+              id: 'custom-item-2',
             },
             value: 'no',
             label: 'No',
@@ -710,7 +709,7 @@ describe('FormGroup', () => {
       />
     );
 
-    expect(screen.getByTestId('custom-item-2')).toBeDisabled();
+    expect(screen.getAllByRole('checkbox')[1]).toBeDisabled();
   });
 
   it('should render a form group with shared values', () => {
@@ -740,7 +739,7 @@ describe('FormGroup', () => {
         items={[
           {
             inputProps: {
-              'data-testid': 'custom-item',
+              id: 'custom-item',
             },
             labelProps: {
               id: 'yesId',
@@ -751,7 +750,7 @@ describe('FormGroup', () => {
           },
           {
             inputProps: {
-              'data-testid': 'custom-item-2',
+              id: 'custom-item-2',
             },
             labelProps: {
               id: 'NoId',
@@ -765,17 +764,17 @@ describe('FormGroup', () => {
       />
     );
 
-    expect(screen.getByTestId('custom-item').getAttribute('name')).toBe(
+    expect(screen.getAllByRole('radio')[0].getAttribute('name')).toBe(
       'shared-name'
     );
-    expect(screen.getByTestId('custom-item-2').getAttribute('name')).toBe(
+    expect(screen.getAllByRole('radio')[1].getAttribute('name')).toBe(
       'shared-name'
     );
 
-    expect(screen.getByTestId('custom-item').getAttribute('class')).toBe(
+    expect(screen.getAllByRole('radio')[0].getAttribute('class')).toBe(
       'shared-input-class'
     );
-    expect(screen.getByTestId('custom-item-2').getAttribute('class')).toBe(
+    expect(screen.getAllByRole('radio')[1].getAttribute('class')).toBe(
       'shared-input-class'
     );
 

--- a/src/formRadio/FormRadio.tsx
+++ b/src/formRadio/FormRadio.tsx
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
+import { Roles } from '../common';
 
 import { Hint, Conditional } from '../common/components';
 
@@ -20,31 +21,48 @@ export const FormRadio = ({
   itemProps,
   labelProps,
   name,
+  nested,
   selected,
   onChange,
 }: FormRadioProps) => {
   const conditionalReveal = (): boolean =>
     !_.isEmpty(conditional) && selected === true;
 
-  return (
-    <div {...itemProps}>
-      <input
-        id={id}
-        type="radio"
-        value={value}
-        name={name}
-        aria-label={ariaLabel || name}
-        data-aria-controls={ariaDataControls || ''}
-        aria-describedby={ariaDescribedBy || ''}
-        aria-labelledby={ariaLabelledBy || labelProps ? labelProps.id : ''}
-        disabled={disabled}
-        checked={selected}
-        {...inputProps}
-        onChange={onChange}
-      />
+  const input: JSX.Element = (
+    <input
+      id={id}
+      type="radio"
+      role={Roles.formRadio}
+      value={value}
+      name={name}
+      aria-label={ariaLabel || name}
+      data-aria-controls={ariaDataControls || ''}
+      aria-describedby={ariaDescribedBy || ''}
+      aria-labelledby={ariaLabelledBy || labelProps?.id}
+      disabled={disabled}
+      checked={selected}
+      {...inputProps}
+      onChange={onChange}
+    />
+  );
+
+  const radio: JSX.Element = nested ? (
+    <label {...labelProps}>
+      {input}
+      {label}
+    </label>
+  ) : (
+    <>
+      {input}
       <label {...labelProps} htmlFor={id}>
         {label}
       </label>
+    </>
+  );
+
+  return (
+    <div {...itemProps}>
+      {radio}
       {hint && <Hint {...hint} />}
       {conditional !== undefined &&
         conditionalReveal() &&

--- a/src/formRadio/__test__/FormRadio.test.tsx
+++ b/src/formRadio/__test__/FormRadio.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, queryByAttribute } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import fireEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { FormRadio } from '../FormRadio';
@@ -21,20 +21,48 @@ describe('FormRadio', () => {
     expect(screen.getByRole('radio')).toBeInTheDocument();
   });
 
-  it('should render a radio with a label', () => {
+  it('should render a radio with a sibling label', () => {
     const handleChange = jest.fn();
 
-    render(
+    const { container } = render(
       <FormRadio
         id="myId"
         value="choice 1"
         label="my label"
+        labelProps={{
+          id: 'my-label',
+        }}
         name="group1"
         onChange={handleChange}
       />
     );
 
+    const label: HTMLElement | null = container.querySelector('#my-label');
+
     expect(screen.getByLabelText('my label')).toBeInTheDocument();
+    expect(container.querySelector('input[type=radio]')).not.toBeNull();
+    expect(label?.querySelector('input[type=radio]')).toBeNull();
+  });
+
+  it('should render a nested radio within  label', () => {
+    const { container } = render(
+      <FormRadio
+        id="myId"
+        value="choice 1"
+        label="my label"
+        labelProps={{
+          id: 'my-label',
+        }}
+        name="group1"
+        nested={true}
+      />
+    );
+
+    const label: HTMLElement | null = container.querySelector('#my-label');
+
+    expect(screen.getByLabelText('my label')).toBeInTheDocument();
+    expect(container.querySelector('input[type=radio]')).not.toBeNull();
+    expect(label?.querySelector('input[type=radio]')).not.toBeNull();
   });
 
   it('should render a radio with a value', () => {
@@ -110,7 +138,7 @@ describe('FormRadio', () => {
   it('should set radio as checked if specified', () => {
     const handleChange = jest.fn();
 
-    render(
+    const { container } = render(
       <FormRadio
         id="myId"
         value="choice 1"
@@ -118,20 +146,20 @@ describe('FormRadio', () => {
         selected={true}
         name="group1"
         onChange={handleChange}
-        itemProps={{ 'data-testid': 'radio-container' }}
+        itemProps={{ id: 'radio-container' }}
       />
     );
-    const container: HTMLElement = screen.getByTestId('radio-container');
-    const getById = queryByAttribute.bind(null, 'id');
 
-    expect(getById(container, 'myId')).toBeChecked();
-    expect(getById(container, 'myId')).not.toBeDisabled();
+    const radio: HTMLElement | null = container.querySelector('#myId');
+
+    expect(radio).toBeChecked();
+    expect(radio).not.toBeDisabled();
   });
 
   it('should set radio as disabled if specified', () => {
     const handleChange = jest.fn();
 
-    render(
+    const { container } = render(
       <FormRadio
         id="myId"
         value="choice 1"
@@ -139,14 +167,14 @@ describe('FormRadio', () => {
         name="group1"
         disabled={true}
         onChange={handleChange}
-        itemProps={{ 'data-testid': 'radio-container' }}
+        itemProps={{ id: 'radio-container' }}
       />
     );
-    const container: HTMLElement = screen.getByTestId('radio-container');
-    const getById = queryByAttribute.bind(null, 'id');
 
-    expect(getById(container, 'myId')).not.toBeChecked();
-    expect(getById(container, 'myId')).toBeDisabled();
+    const radio: HTMLElement | null = container.querySelector('#myId');
+
+    expect(radio).not.toBeChecked();
+    expect(radio).toBeDisabled();
   });
 
   it('should render hint text', () => {

--- a/stories/FormCheckbox/Documentation.stories.mdx
+++ b/stories/FormCheckbox/Documentation.stories.mdx
@@ -64,6 +64,7 @@ An example with all the available properties is:
     inputId: 'input-id',
     labelClassName: 'label-classes',
   }}
+  nested={false}
 />
 ```
 

--- a/stories/FormCheckbox/UnStyled.stories.mdx
+++ b/stories/FormCheckbox/UnStyled.stories.mdx
@@ -188,6 +188,34 @@ By default, the hint will display underneath the checkbox
   </Story>
 </Canvas>
 
+### Example of nested checkbox
+
+<Canvas>
+  <Story name="nested">
+    {() => {
+      const [value, setValue] = React.useState('');
+      const [checked, setChecked] = React.useState(false);
+      const handleChange = event => {
+        setValue(event.currentTarget.value);
+        setChecked(!checked);
+      };
+      return (
+        <FormCheckbox
+          label="checkbox label"
+          value={value}
+          id="checkbox-7"
+          inputProps={{
+            name: 'checkbox-7',
+          }}
+          onChange={handleChange}
+          selected={checked}
+          nested={true}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
 ### List of properties
 
 <Props of={FormCheckbox} />

--- a/stories/FormRadio/Documentation.stories.mdx
+++ b/stories/FormRadio/Documentation.stories.mdx
@@ -59,6 +59,7 @@ An example with all the available properties is:
     style: { display: 'flex' },
   }}
   name="radio-name"
+  nested={false}
   onChange={handleChange}
   selected={true}
 />

--- a/stories/FormRadio/UnStyled.stories.mdx
+++ b/stories/FormRadio/UnStyled.stories.mdx
@@ -27,6 +27,30 @@ import '../style.css';
   </Story>
 </Canvas>
 
+### An example of 'nested' Input
+
+<Canvas>
+  <Story name="nested">
+    {() => {
+      const [value, setValue] = React.useState('');
+      const handleChange = event => {
+        setValue(event.currentTarget.value);
+      };
+      return (
+        <FormRadio
+          label="text example 2"
+          name="group2"
+          value="value2"
+          id="radio-2"
+          onChange={handleChange}
+          nested={true}
+        />
+      );
+    }}
+    />
+  </Story>
+</Canvas>
+
 ### Properties
 
 <Props of={FormRadio} />

--- a/stories/liveEdit/FormCheckboxLive.tsx
+++ b/stories/liveEdit/FormCheckboxLive.tsx
@@ -47,6 +47,7 @@ function FormCheckboxDemo() {
         labelClassName: "",
       }}
       selected={checked}
+      nested={false}
     />
   );
 }

--- a/stories/liveEdit/FormRadioLive.tsx
+++ b/stories/liveEdit/FormRadioLive.tsx
@@ -42,6 +42,7 @@ function FormRadioDemo() {
         itemProps={{}}
         labelProps={{}}
         selected={value === 'value'}
+        nested={false}
       />
       <FormRadio
         label="text example two"
@@ -63,6 +64,7 @@ function FormRadioDemo() {
         itemProps={{}}
         labelProps={{}}
         selected={value === 'value-two'}
+        nested={false}
       />
     </>
   );

--- a/stories/liveEdit/MultiSelectLive.tsx
+++ b/stories/liveEdit/MultiSelectLive.tsx
@@ -96,8 +96,6 @@ function MultiSelectDemo() {
           }}
           searchDebounceMs={0}
           hintText="Enter your search term to add a selection"
-          placeholder="Select..."
-          placeholder="Select..."
           onRemove={handleRemove}
           onSelect={handleSelect}
           onRemoveAll={handleRemoveAll}


### PR DESCRIPTION
```jsx
// Checkbox
<FormCheckbox label="checkbox label" value={value} id="checkbox-7" inputProps={{
    name: 'checkbox-7'
  }} onChange={handleChange} selected={checked} nested={true} />;
  
  <div>
    <label>
      <input id="checkbox-7" type="checkbox" name="checkbox-7" data-aria-controls="" aria-describedby="" value="">
      checkbox label
   </label>
</div>
```

```jsx
// Radio
<FormRadio label="text example 2" name="group2" value="value2" id="radio-2"
 onChange={handleChange} nested={true} />;
 
 <div>
  <label>
   <input id="radio-2" type="radio" role="radio" name="group2" aria-label="group2" data-aria-controls="" aria- 
    describedby="" value="value2">
    text example 2
   </label>
 </div>
```
