### PR TITLE
feat: add copyToClipboard component

### DIFF
--- a/example/components/CopyToClipboardDemo.tsx
+++ b/example/components/CopyToClipboardDemo.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { CopyToClipboard } from 'dcx-react-library';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCopy } from '@fortawesome/free-solid-svg-icons';
+export const CopyToClipboardDemo = () => {
+  const [value, setValue] = React.useState('');
+  const inputRef = React.useRef(null);
+  return (
+    <div>
+      <input
+        value={value}
+        ref={inputRef}
+        onChange={evt => setValue(evt.currentTarget.value)}
+      />
+      <div>
+        <CopyToClipboard
+          ref={inputRef}
+          onCopy={value => {
+            alert(value);
+          }}
+        />
+        <CopyToClipboard
+          ref={inputRef}
+          onCopy={value => {
+            alert(value);
+          }}
+        >
+          Copy
+        </CopyToClipboard>
+
+        <CopyToClipboard
+          ref={inputRef}
+          onCopy={value => {
+            alert(value);
+          }}
+          icon={<FontAwesomeIcon icon={faCopy} />}
+        />
+      </div>
+    </div>
+  );
+};

--- a/example/components/index.ts
+++ b/example/components/index.ts
@@ -10,4 +10,5 @@ export { FormSelectDemo } from './FormSelectDemo';
 export { MultiUploadDemo } from './MultiUploadDemo';
 export { MultiSelectDemo } from './MultiSelectDemo';
 export { FormDateDemo } from './FormDateDemo';
+export { CopyToClipboardDemo } from './CopyToClipboardDemo';
 export * from './library-candidates';

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -15,6 +15,7 @@ import {
   MultiSelectDemo,
   FormDateDemo,
   FormInputDemo,
+  CopyToClipboardDemo,
 } from './components';
 import './global-styles.scss';
 import { Login } from './pages/Login';
@@ -39,6 +40,7 @@ const App = () => (
         <Route path="/multiUpload" component={MultiUploadDemo} />
         <Route path="/multiSelect" component={MultiSelectDemo} />
         <Route path="/formDate" component={FormDateDemo} />
+        <Route path="/copyToClipboard" component={CopyToClipboardDemo} />
       </Switch>
     </BrowserRouter>
   </div>

--- a/example/pages/HomePage.tsx
+++ b/example/pages/HomePage.tsx
@@ -50,6 +50,9 @@ export const Home = () => (
         <li>
           <Link to="/formDate">FormDateDemo</Link>
         </li>
+        <li>
+          <Link to="/copyToClipboard">CopyToClipboardDemo</Link>
+        </li>
       </ul>
     </nav>
     <h1>Home</h1>

--- a/src/copyToClipboard/CopyToClipboard.tsx
+++ b/src/copyToClipboard/CopyToClipboard.tsx
@@ -1,0 +1,24 @@
+import React, { MutableRefObject } from 'react';
+type CopyToClipboardProps = {
+  icon?: JSX.Element;
+  onCopy: (value: string) => void;
+  children?: JSX.Element;
+};
+
+export const CopyToClipboard = React.forwardRef<
+  HTMLInputElement,
+  CopyToClipboardProps
+>(({ icon, onCopy, children }, ref) => {
+  const onClickHandler = () => {
+    const inputRef = ref as MutableRefObject<HTMLInputElement>;
+    inputRef.current.select();
+    document.execCommand('copy');
+    onCopy(inputRef.current.value);
+  };
+  return (
+    <button onClick={onClickHandler}>
+      {icon}
+      {children}
+    </button>
+  );
+});

--- a/src/copyToClipboard/__test__/CopyToClipboard.test.tsx
+++ b/src/copyToClipboard/__test__/CopyToClipboard.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { CopyToClipboard } from '../CopyToClipboard';
+import '@testing-library/jest-dom';
+const DummyCopyToClipboard = () => {
+  const [copy, setCopy] = React.useState('');
+  const inputRef = React.useRef(null);
+  return (
+    <>
+      <input value="this is a test" ref={inputRef} onChange={() => {}} />
+      <CopyToClipboard
+        ref={inputRef}
+        onCopy={value => {
+          setCopy(value);
+        }}
+      />
+      <div data-testid="copied">{copy}</div>
+    </>
+  );
+};
+const mockUseRef = (obj: any) => () =>
+  Object.defineProperty({}, 'current', {
+    get: () => obj,
+    set: () => {},
+  });
+
+describe('CopyToClipboard', () => {
+  beforeEach(() => {
+    document.execCommand = jest.fn();
+  });
+  it('should render the component', () => {
+    const inputRef = mockUseRef({ refFunction: jest.fn() });
+    const onCopyHandler = jest.fn();
+    render(<CopyToClipboard ref={inputRef} onCopy={onCopyHandler} />);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+  });
+  it('should render an icon', () => {
+    const inputRef = mockUseRef({ refFunction: jest.fn() });
+    const onCopyHandler = jest.fn();
+    render(
+      <CopyToClipboard
+        ref={inputRef}
+        onCopy={onCopyHandler}
+        icon={<img src="" alt="test" />}
+      />
+    );
+    const icon = screen.getByRole('img');
+    expect(icon).toBeInTheDocument();
+  });
+  it('should render a custom content', () => {
+    const inputRef = mockUseRef({ refFunction: jest.fn() });
+    const onCopyHandler = jest.fn();
+    render(
+      <CopyToClipboard ref={inputRef} onCopy={onCopyHandler}>
+        <div>custom</div>
+      </CopyToClipboard>
+    );
+    const customValue = screen.getByText('custom');
+    expect(customValue).toBeInTheDocument();
+  });
+  it('should copy the content', () => {
+    render(<DummyCopyToClipboard />);
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    const copiedValue = screen.getByTestId('copied');
+    expect(copiedValue.innerHTML).toBe('this is a test');
+  });
+});

--- a/src/copyToClipboard/index.ts
+++ b/src/copyToClipboard/index.ts
@@ -1,0 +1,1 @@
+export { CopyToClipboard } from './CopyToClipboard';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export * from './formSelect';
 export * from './multiUpload';
 export * from './multiSelect';
 export * from './formDate';
+export * from './copyToClipboard';
 export * from './generatePresentationalComponent/generateComponent';
 export * from './generatePresentationalComponent/generateStyle';
 export { DynamicComponent } from './common/components/DynamicComponent';


### PR DESCRIPTION
Adding the copy to clipboard component:

- [x] demo
- [x] code
- [x] test
- [ ] storybook

Result:
![Screenshot 2021-05-27 at 19 26 00](https://user-images.githubusercontent.com/3193095/119877824-6983bf80-bf21-11eb-8e08-e3e8a669a797.png)

the first one is an empty copy
the second one is with custom content
the third one is with an icon