### PR TITLE
feat: adding ability to add items with the same label and value

### DIFF
--- a/example/src/components/FormCheckboxDemo.tsx
+++ b/example/src/components/FormCheckboxDemo.tsx
@@ -132,6 +132,13 @@ export const FormCheckboxDemo = () => {
           },
         }}
       />
+      <h2>Group using string values</h2>
+      <FormGroup
+        name="name-of-group-string"
+        type="checkbox"
+        onChange={handleFormChange}
+        items={['yes', 'no']}
+      />
       <pre>{formValue}</pre>
     </>
   );

--- a/example/src/components/FormRadioDemo.tsx
+++ b/example/src/components/FormRadioDemo.tsx
@@ -209,6 +209,17 @@ export const FormRadioDemo = () => {
         //@ts-ignore
         onChange={handleGroupConditionalChange}
       />
+      <h4 id="basic-radio-group-with-string-tag">
+        Basic Group Radios using string
+      </h4>
+      <FormGroup
+        ariaDescribedBy="basic-radio-group-tag"
+        name="group4"
+        type="radio"
+        items={['Option 1', 'Option 2', 'Option 3']}
+        //@ts-ignore
+        onChange={handleGroupConditionalChange}
+      />
       <br />
     </>
   );

--- a/src/formGroup/__test__/FormGroup.test.tsx
+++ b/src/formGroup/__test__/FormGroup.test.tsx
@@ -40,6 +40,31 @@ describe('FormGroup', () => {
     expect(container.querySelector('input[type=radio]')).toBeInTheDocument();
   });
 
+  it('should render a form group of radio buttons from string items', () => {
+    const handleChange = jest.fn();
+
+    const { container } = render(
+      <FormGroup
+        type="radio"
+        groupClasses=""
+        id=""
+        name=""
+        legend={{
+          text: 'Have you changed your name?',
+          heading: {
+            priority: 1,
+          },
+        }}
+        items={['Yes', 'No']}
+        onChange={handleChange}
+      />
+    );
+
+    expect(screen.getByRole('group')).toBeInTheDocument();
+    expect(container.querySelector('input[id=Yes]')).toBeInTheDocument();
+    expect(container.querySelector('input[id=No]')).toBeInTheDocument();
+  });
+
   it('should render a form group of checkboxes', () => {
     const handleChange = jest.fn();
 
@@ -363,6 +388,30 @@ describe('FormGroup', () => {
             id: 'second',
           },
         ]}
+        onChange={handleChange}
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole('radio')[0]);
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it('should call on change of a string item if an input has changed', () => {
+    const handleChange = jest.fn();
+
+    render(
+      <FormGroup
+        type="radio"
+        groupClasses=""
+        id=""
+        name="group1"
+        legend={{
+          text: 'Have you changed your name?',
+          heading: {
+            priority: 1,
+          },
+        }}
+        items={['yes', 'no']}
         onChange={handleChange}
       />
     );

--- a/stories/FormGroup/UnStyled.stories.mdx
+++ b/stories/FormGroup/UnStyled.stories.mdx
@@ -42,6 +42,26 @@ import '../style.css';
   </Story>
 </Canvas>
 
+### An example of 'un-styled' FormGroup of radio buttons
+
+<Canvas>
+  <Story name="un-styled-radios-with-strings">
+    {() => {
+      const [selected, setSelected] = React.useState('');
+      const handleChange = event => setSelected(event.currentTarget.value);
+      return (
+        <FormGroup
+          name="name-of-group"
+          type="radio"
+          items={['yes','no']}
+          onChange={handleChange}
+        />
+      );
+    }}
+    />
+  </Story>
+</Canvas>
+
 ### An example of 'un-styled' FormGroup of checkboxes
 
 <Canvas>


### PR DESCRIPTION
#252 Part One Only

```jsx
items={[{
 label: 'Form Group',
 value: 'Form Group'
}]}
```
Offers the developer using `FormGroup` the ability to add items with the same label and value like so:

```jsx
items={['Form Group'] }
```