### PR TITLE
feat: hides error element if text is not present

### DIFF
--- a/src/common/components/ErrorMessage.tsx
+++ b/src/common/components/ErrorMessage.tsx
@@ -6,13 +6,23 @@ export const ErrorMessage = ({
   className,
   id,
   visuallyHiddenText,
-}: ErrorMessageProps) => (
-  <span id={id} className={className}>
-    {visuallyHiddenText && (
-      <span className={visuallyHiddenText.className}>
-        {visuallyHiddenText.text}
-      </span>
-    )}
-    {text}
-  </span>
-);
+}: ErrorMessageProps) => {
+  const getErrorElement = () => {
+    let errorElement = <></>;
+    if (text && typeof text === 'string') {
+      errorElement = (
+        <span id={id} className={className}>
+          {visuallyHiddenText && (
+            <span className={visuallyHiddenText.className}>
+              {visuallyHiddenText.text}
+            </span>
+          )}
+          {text}
+        </span>
+      );
+    }
+    return errorElement;
+  };
+
+  return <>{getErrorElement()}</>;
+};

--- a/src/common/components/__tests__/ErrorMessage.test.tsx
+++ b/src/common/components/__tests__/ErrorMessage.test.tsx
@@ -32,4 +32,10 @@ describe('ErrorMessage', () => {
       screen.getByText('This text is visually hidden')
     ).toBeInTheDocument();
   });
+
+  it('will not render any element if the text property is blank', () => {
+    const { container } = render(<ErrorMessage text="" />);
+
+    expect(container.querySelector('span')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Hides the error element in the ErrorMessage component if the text property is not present

https://github.com/Capgemini/dcx-react-library/issues/315