### PR TITLE
fix: On initial render, ensure that the input prompt for Autocomplete is not visible unless focused

### DIFF
--- a/src/autocomplete/Autocomplete.tsx
+++ b/src/autocomplete/Autocomplete.tsx
@@ -257,18 +257,26 @@ export const Autocomplete = ({
   const [userInput, setUserInput] = useState<string>(defaultValue);
   let hydrated = useHydrated();
 
-  const showPromptMessage = (): boolean =>
-    userInput.trim().length === 0 &&
+  const showPromptMessage = (inputValue = userInput): boolean =>
+    inputValue.trim().length === 0 &&
     promptCondition() &&
     promptMessage.length > 0;
 
-  const showMinCharsMessage = (): boolean =>
+  const showMinCharsMessage = (inputValue = userInput): boolean =>
     !showPromptMessage() &&
-    userInput.trim().length < minCharsBeforeSearch &&
+    inputValue.trim().length < minCharsBeforeSearch &&
     minCharsMessage.length > 0;
 
-  const handlePrompt = () => {
-    const canShowPrompt = showMinCharsMessage() || showPromptMessage();
+  const displayResultList = (inputValue = userInput): boolean =>
+    showOptions && inputValue.trim().length >= minCharsBeforeSearch;
+
+  const handlePrompt = (
+    _evt: React.FormEvent<HTMLInputElement>,
+    inputValue = userInput
+  ) => {
+    const canShowPrompt =
+      !displayResultList(inputValue) &&
+      (showMinCharsMessage(inputValue) || showPromptMessage(inputValue));
 
     if (!showPrompt && canShowPrompt) {
       setShowPrompt(true);
@@ -315,6 +323,7 @@ export const Autocomplete = ({
 
     const { value } = evt.currentTarget;
     setUserInput(value);
+    handlePrompt(evt, value);
 
     if (onChange) {
       debounceSearch(value);
@@ -330,10 +339,6 @@ export const Autocomplete = ({
       setShowOptions(true);
     }
   }, [options, onChange]);
-
-  React.useEffect(() => {
-    handlePrompt();
-  }, [userInput]);
 
   const handleClick = (evt: React.FormEvent<HTMLInputElement>) => {
     setActiveOption(0);
@@ -361,9 +366,6 @@ export const Autocomplete = ({
       setActiveOption(activeOption + 1);
     }
   };
-
-  const displayResultList = (): boolean =>
-    showOptions && userInput.trim().length >= minCharsBeforeSearch;
 
   const formInput: JSX.Element = (
     <>

--- a/src/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/src/autocomplete/__tests__/Autocomplete.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Autocomplete, AutoCompleteErrorPosition } from '../';
 import userEvent from '@testing-library/user-event';
+import { act } from '@testing-library/react-hooks';
 import * as hooks from '../../common/utils/clientOnly';
 
 const firstSearch = [
@@ -511,6 +512,7 @@ describe('Autocomplete', () => {
   it('should display a prompt if receiving focus and the minimum number of characters have not yet been entered', async () => {
     jest.spyOn(hooks, 'useHydrated').mockImplementation(() => true);
 
+    const user = userEvent.setup();
     const minCharsBeforeSearch = 2;
     const minCharsMessage = `Please type at least ${minCharsBeforeSearch} character(s) to see the available options`;
     const promptId = 'input-prompt';
@@ -527,7 +529,10 @@ describe('Autocomplete', () => {
     );
 
     const input: any = screen.getByRole('textbox');
-    input.focus();
+
+    expect(input).not.toHaveAttribute('aria-describedby');
+
+    await act(() => user.click(input));
 
     expect(input).toHaveAttribute('aria-describedby');
 
@@ -535,8 +540,9 @@ describe('Autocomplete', () => {
 
     expect(prompt.innerHTML).toBe(minCharsMessage);
 
-    // check if prompt is hidden on blur
-    fireEvent.blur(input);
+    act(() => {
+      fireEvent.blur(input);
+    });
 
     expect(input).not.toHaveAttribute('aria-describedby');
 
@@ -566,9 +572,13 @@ describe('Autocomplete', () => {
 
     const input: any = screen.getByRole('textbox');
 
+    expect(input).not.toHaveAttribute('aria-describedby');
+
+    await act(() => user.click(input));
+
     expect(input).toHaveAttribute('aria-describedby');
 
-    await user.type(input, 'da');
+    await act(() => user.type(input, 'da'));
 
     expect(input).not.toHaveAttribute('aria-describedby');
 
@@ -600,7 +610,10 @@ describe('Autocomplete', () => {
     );
 
     const input: any = screen.getByRole('textbox');
-    input.focus();
+
+    expect(input).not.toHaveAttribute('aria-describedby');
+
+    await act(() => user.click(input));
 
     expect(input).toHaveAttribute('aria-describedby');
 
@@ -609,7 +622,7 @@ describe('Autocomplete', () => {
     expect(prompt.innerHTML).toBe(promptMessage);
 
     // check if user input is prevented and the prompt is still visible
-    await user.type(input, 'd');
+    await act(() => user.type(input, 'd'));
 
     expect(input.value).toContain('');
     expect(input).toHaveAttribute('aria-describedby');
@@ -634,6 +647,7 @@ describe('Autocomplete', () => {
   it('conditional prompt should take precedence over the minChars if both props are provided', async () => {
     jest.spyOn(hooks, 'useHydrated').mockImplementation(() => true);
 
+    const user = userEvent.setup();
     const minCharsBeforeSearch = 2;
     const minCharsMessage = `Please type at least ${minCharsBeforeSearch} character(s) to see the available options`;
     const promptMessage = 'Enter a valid date before typing here';
@@ -653,7 +667,10 @@ describe('Autocomplete', () => {
     );
 
     const input: any = screen.getByRole('textbox');
-    input.focus();
+
+    expect(input).not.toHaveAttribute('aria-describedby');
+
+    await act(() => user.click(input));
 
     expect(input).toHaveAttribute('aria-describedby');
 


### PR DESCRIPTION
## Before: Prompt is visible on initial render even when the input does not have focus

<img width="739" alt="Screenshot 2022-10-31 at 13 59 12" src="https://user-images.githubusercontent.com/27343753/199027782-90a33e49-48d0-4b06-9c77-8c419418dcc4.png">


## After: Prompt is no longer visible on initial render unless the input has focus

<img width="750" alt="Screenshot 2022-10-31 at 14 03 24" src="https://user-images.githubusercontent.com/27343753/199027918-437e1591-b5ef-4f9b-b552-9d11c98d7533.png">

Fixes #355 