### PR TITLE
fix: [Autocomplete] Ensure the value of controlled input is never undefined

### DIFF
--- a/src/autocomplete/Autocomplete.tsx
+++ b/src/autocomplete/Autocomplete.tsx
@@ -352,7 +352,7 @@ export const Autocomplete = ({
     if (evt.code === 'Enter') {
       setActiveOption(0);
       setShowOptions(false);
-      setUserInput(filterList[activeOption]);
+      setUserInput(filterList[activeOption] || '');
       if (onSelected) onSelected(filterList[activeOption]);
     } else if (evt.code === 'ArrowUp') {
       if (activeOption === 0) {

--- a/src/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/src/autocomplete/__tests__/Autocomplete.test.tsx
@@ -305,6 +305,16 @@ describe('Autocomplete', () => {
     });
   });
 
+  it('should set the input to an empty string when there is no text in the input and on pressing Enter', async () => {
+    render(<Autocomplete options={['daniele', 'darren', 'isaac']} />);
+
+    const input: any = screen.getByRole('textbox');
+
+    fireEvent.keyDown(input, { code: 'Enter', keyCode: 13 });
+
+    expect(input.value).toBe('');
+  });
+
   it('should highlight the selected option(s) on keyDown', async () => {
     const user = userEvent.setup();
     render(<Autocomplete options={['daniele', 'darren', 'isaac']} />);


### PR DESCRIPTION
## Before: Console warning and error when pressing enter when the input is blank

<img width="1562" alt="Screenshot 2022-10-31 at 15 17 50" src="https://user-images.githubusercontent.com/27343753/199044739-7721bfe5-a8a2-4672-bbd0-1d19a3d45c3c.png">


## After: No longer seeing console warnings or errors when pressing enter when the input is blank

<img width="1562" alt="Screenshot 2022-10-31 at 15 19 23" src="https://user-images.githubusercontent.com/27343753/199044869-807cce19-7232-46c6-bf28-a6c6e549797f.png">

Fixes #354 