### PR TITLE
fix: formSelect to accept tabIndex prop

### DIFF
--- a/src/formSelect/FormSelect.tsx
+++ b/src/formSelect/FormSelect.tsx
@@ -107,7 +107,11 @@ export type FormSelectProps = {
   /**
    * provide an container props
    */
-   containerProps?: any;
+  containerProps?: any;
+  /**
+   * tab index value
+   */
+  tabIndex?: number;
 };
 
 export const FormSelect = ({
@@ -133,6 +137,7 @@ export const FormSelect = ({
   nullOption,
   containerProps,
   defaultValue = '',
+  tabIndex = 0,
 }: FormSelectProps) => {
   let initialValue: string | number = '';
 
@@ -198,6 +203,7 @@ export const FormSelect = ({
         aria-label={ariaLabel || Roles.list}
         onChange={handleChange}
         style={style}
+        tabIndex={tabIndex}
       >
         {nullOption && <Option value="" label={nullOption} />}
         {getOptions(options)}

--- a/src/formSelect/__test__/FormSelect.test.tsx
+++ b/src/formSelect/__test__/FormSelect.test.tsx
@@ -454,10 +454,22 @@ describe('FormSelect', () => {
   it('should read the containerProps', () => {
     render(
       <FormSelect
-        containerProps={{ 'data-testid': 'container-props', id: 4}}
+        containerProps={{ 'data-testid': 'container-props', id: 4 }}
       />
     );
     const container: any = screen.getByTestId('container-props');
     expect(container).toBeInTheDocument();
+  });
+
+  it('should have a 0 tabIndex value by default', () => {
+    const { container } = render(<FormSelect id="select" />);
+    const select: any = container.querySelector('#select');
+    expect(select.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('should take tabIndex attribute', () => {
+    const { container } = render(<FormSelect id="select" tabIndex={1} />);
+    const select: any = container.querySelector('#select');
+    expect(select.getAttribute('tabindex')).toBe('1');
   });
 });

--- a/stories/FormSelect/Documentation.stories.mdx
+++ b/stories/FormSelect/Documentation.stories.mdx
@@ -132,6 +132,7 @@ An example with all the available properties is:
       }
     }}
     defaultValue="option1"
+    tabIndex={0}
   />
 ```
 

--- a/stories/liveEdit/FormSelectLive.tsx
+++ b/stories/liveEdit/FormSelectLive.tsx
@@ -57,6 +57,7 @@ function FormSelectDemo() {
       }}
       errorMessageId=""
       defaultValue=""
+      tabIndex={0}
     />
   );
 }


### PR DESCRIPTION
Issue: https://github.com/Capgemini/dcx-react-library/issues/301

Capability to take a tabIndex that can added to the element within the DOM has been added to FormSelect component.

