### PR TITLE
fix: multi select can accept tabindex

### DIFF
--- a/src/autocomplete/Autocomplete.tsx
+++ b/src/autocomplete/Autocomplete.tsx
@@ -201,6 +201,10 @@ type autocompleteProps = {
     content?: JSX.Element | string;
     properties: React.HTMLAttributes<HTMLDivElement>;
   };
+  /**
+   * tab index value to focus on the input
+   */
+  tabIndex?: number;
 };
 
 export enum AutoCompleteErrorPosition {
@@ -256,6 +260,7 @@ export const Autocomplete = ({
   selectProps,
   prefix,
   suffix,
+  tabIndex = 0,
 }: autocompleteProps) => {
   const [activeOption, setActiveOption] = useState<number>(0);
   const [filterList, setFilterList] = useState<string[]>([]);
@@ -404,6 +409,7 @@ export const Autocomplete = ({
           ...inputProps,
           ...(showPrompt && { 'aria-describedby': promptId }),
         }}
+        tabIndex={tabIndex}
       />
       {showPrompt && (
         <div className={promptClassName} id={promptId}>

--- a/src/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/src/autocomplete/__tests__/Autocomplete.test.tsx
@@ -760,4 +760,18 @@ describe('Autocomplete', () => {
       expect(el.id).toBe('');
     });
   });
+
+  it('should have a 0 tabIndex value by default', () => {
+    render(<Autocomplete options={['daniele', 'isaac']} />);
+
+    const input: any = screen.getByRole('textbox');
+    expect(input.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('should accept tabIndex attribute', () => {
+    render(<Autocomplete options={['daniele', 'isaac']} tabIndex={1} />);
+
+    const input: any = screen.getByRole('textbox');
+    expect(input.getAttribute('tabindex')).toBe('1');
+  });
 });

--- a/src/formInput/FormInput.tsx
+++ b/src/formInput/FormInput.tsx
@@ -119,6 +119,10 @@ type FormInputProps = {
    * Specifies if that field needs to be filled or not
    */
   required?: boolean;
+  /**
+   * tab index value
+   */
+  tabIndex?: number;
 };
 
 export enum ErrorPosition {
@@ -155,6 +159,7 @@ export const FormInput = ({
   required,
   hint,
   inputDivProps = { style: { display: 'flex' } },
+  tabIndex = 0,
 }: FormInputProps) => {
   const { validity, onValueChange } = useValidationOnChange(validation, value);
 
@@ -213,6 +218,7 @@ export const FormInput = ({
       className={inputClassName}
       aria-label={ariaLabel || name}
       aria-required={ariaRequired}
+      tabIndex={tabIndex}
       {...inputProps}
     />
   );

--- a/src/formInput/__tests__/FormInput.test.tsx
+++ b/src/formInput/__tests__/FormInput.test.tsx
@@ -436,4 +436,18 @@ describe('FormInput', () => {
     const input = screen.getByRole('textbox');
     expect(input.getAttribute('aria-label')).toBe('password');
   });
+
+  it('should have a 0 tabIndex value by default', () => {
+    render(<FormInput name="password" type="text" value="test" />);
+
+    const input: any = screen.getByRole('textbox');
+    expect(input.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('should accept tabIndex attribute', () => {
+    render(<FormInput name="password" type="text" value="test" tabIndex={1} />);
+
+    const input: any = screen.getByRole('textbox');
+    expect(input.getAttribute('tabindex')).toBe('1');
+  });
 });

--- a/src/multiSelect/MultiSelect.tsx
+++ b/src/multiSelect/MultiSelect.tsx
@@ -91,6 +91,10 @@ export type MultiSelectProps = {
    * Multi Select onSelect
    */
   onSelect?: (value: string) => void;
+  /**
+   * tab index value to focus on input field
+   */
+  tabIndex?: number;
 };
 
 function multiSelectReducer(
@@ -156,6 +160,7 @@ export const MultiSelect = ({
   onRemove,
   onRemoveAll,
   onSelect,
+  tabIndex = 0,
 }: MultiSelectProps) => {
   const [state, dispatch] = useReducer(multiSelectReducer, {
     selected: selectOptions
@@ -278,6 +283,7 @@ export const MultiSelect = ({
           onRemove={onRemoveHandler}
           onRemoveAll={onRemoveAllHander}
           onFocus={onFocusHandler}
+          tabIndex={tabIndex}
         />
       </div>
     </div>

--- a/src/multiSelect/__test__/MultiSelect.test.tsx
+++ b/src/multiSelect/__test__/MultiSelect.test.tsx
@@ -90,6 +90,24 @@ describe('MultiSelect', () => {
         'my-hint-class'
       );
     });
+
+    it('should have a 0 tabindex value by default', () => {
+      const options: MultiSelectOption[] = [];
+
+      render(<MultiSelect selectOptions={options} />);
+
+      const input = screen.getByRole('textbox');
+      expect(input.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('should accept tabIndex attribute', () => {
+      const options: MultiSelectOption[] = [];
+
+      render(<MultiSelect selectOptions={options} tabIndex={1} />);
+
+      const input = screen.getByRole('textbox');
+      expect(input.getAttribute('tabindex')).toBe('1');
+    });
   });
 
   describe('when rendering the selected list', () => {

--- a/stories/Autocomplete/Documentation.stories.mdx
+++ b/stories/Autocomplete/Documentation.stories.mdx
@@ -65,6 +65,7 @@ An example with all the available properties is (the only mandatory property is 
   name=""
   inputProps={{}}
   selectProps={{}}
+  tabIndex={0}
 />
 ```
 

--- a/stories/Input/Documentation.stories.mdx
+++ b/stories/Input/Documentation.stories.mdx
@@ -90,6 +90,7 @@ An example with all the available properties is:
   }}
   staticErrorMessage="static error message"
   containerClassNameError="containerClassNameError"
+  tabIndex={0}
 />
 ```
 

--- a/stories/MultiSelect/Documentation.stories.mdx
+++ b/stories/MultiSelect/Documentation.stories.mdx
@@ -69,6 +69,7 @@ An example with all the available properties is:
   onFocus={onFocusHandler}
   onRemove={onRemoveHandler}
   onRemoveAll={onRemoveAllHandler}
+  tabIndex={0}
 />
 ```
 

--- a/stories/liveEdit/AutocompleteLive.tsx
+++ b/stories/liveEdit/AutocompleteLive.tsx
@@ -32,7 +32,6 @@ function AutocompleteDemo() {
       resultlLiClass=""
       resultNoOptionClass=""
       resultActiveClass=""
-      inputProps={{}}
       notFoundText="No fruit found"
       onSelected={handleSelected} 
       containerClassName=""
@@ -50,6 +49,7 @@ function AutocompleteDemo() {
       name=""
       inputProps={{}}
       selectProps={{}}
+      tabIndex={0}
     />
   )
 }

--- a/stories/liveEdit/FormInputLive.tsx
+++ b/stories/liveEdit/FormInputLive.tsx
@@ -57,6 +57,7 @@ function FormInputDemo() {
         }}
         staticErrorMessage="static error message"
         containerClassNameError="govuk-form-group--error"
+        tabIndex={0}
     />
   )
 }

--- a/stories/liveEdit/MultiSelectLive.tsx
+++ b/stories/liveEdit/MultiSelectLive.tsx
@@ -99,6 +99,7 @@ function MultiSelectDemo() {
           onRemove={handleRemove}
           onSelect={handleSelect}
           onRemoveAll={handleRemoveAll}
+          tabIndex={0}
         />
       </div>
     )


### PR DESCRIPTION
Issue: https://github.com/Capgemini/dcx-react-library/issues/301

Capability to take a tabIndex that can added to the element within the DOM has been added to MultiSelect component.