### PR TITLE
fix: progress tabindex

### DIFF
--- a/src/progress/Progress.tsx
+++ b/src/progress/Progress.tsx
@@ -25,6 +25,10 @@ type ProgressProps = {
    * current value of the progress bar
    */
   value?: number;
+  /**
+   * tab index value
+   */
+  tabIndex?: number;
 };
 
 export const Progress = ({
@@ -34,8 +38,9 @@ export const Progress = ({
   id,
   labelClassName,
   value,
+  tabIndex = 0,
 }: ProgressProps) => (
-  <>
+  <div tabIndex={tabIndex} data-testId={id}>
     <label className={labelClassName} htmlFor={id}>{`${label}: `}</label>
     <progress id={id} className={className} max={max} value={value}>
       <div id={id} className={className}>
@@ -48,5 +53,5 @@ export const Progress = ({
         </span>
       </div>
     </progress>
-  </>
+  </div>
 );

--- a/src/progress/__tests__/Progress.test.tsx
+++ b/src/progress/__tests__/Progress.test.tsx
@@ -44,7 +44,28 @@ describe('Progress', () => {
       <Progress label="Progress" max={100} className="my-class" value={80} />
     );
 
-    expect(container.querySelector('div')?.className).toBe('my-class');
-    expect(container.querySelector('div')?.className).toBe('my-class');
+    expect(container.querySelector('progress>div')?.className).toBe('my-class');
+  });
+
+  it('should have 0 tabIndex value by default', () => {
+    render(<Progress id="progress-id" label="Progress" max={100} value={80} />);
+
+    const container = screen.getByTestId('progress-id');
+    expect(container.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('should accept tabIndex attribute', () => {
+    render(
+      <Progress
+        id="progress-id"
+        label="Progress"
+        max={100}
+        value={80}
+        tabIndex={1}
+      />
+    );
+
+    const container = screen.getByTestId('progress-id');
+    expect(container.getAttribute('tabindex')).toBe('1');
   });
 });

--- a/stories/liveEdit/ProgressLive.tsx
+++ b/stories/liveEdit/ProgressLive.tsx
@@ -13,6 +13,7 @@ function ProgressDemo() {
       className=""
       labelClassName=""
       id="progress"
+      tabIndex={0}
     />
   );
 }

--- a/stories/progress/Documentation.stories.mdx
+++ b/stories/progress/Documentation.stories.mdx
@@ -33,6 +33,7 @@ An example with all the available properties is:
   id="my-id"
   labelClassName="label-class-name"
   value={80}
+  tabIndex={0}
 />
 ```
 


### PR DESCRIPTION
Issue: https://github.com/Capgemini/dcx-react-library/issues/301

Capability to take a tabIndex that can added to the element within the DOM has been added to Progress component.