### PR TITLE
fix: range tabindex

### DIFF
--- a/src/range/Range.tsx
+++ b/src/range/Range.tsx
@@ -51,6 +51,10 @@ type RangeProps = {
    * allow to enable displaying a tooltip on the range slider
    */
   showTooltip?: boolean;
+  /**
+   * tab index value
+   */
+  tabIndex?: number;
 };
 
 export const Range = ({
@@ -66,6 +70,7 @@ export const Range = ({
   onChangeMin,
   inputClass,
   showTooltip = false,
+  tabIndex = 0,
   ...props
 }: RangeProps) => {
   const [defaultValue, setDefaultValue] = React.useState<number>(value);
@@ -119,6 +124,7 @@ export const Range = ({
         aria-label={ariaLabel || 'input-slider'}
         value-tooltip={defaultValue}
         style={styling}
+        tabIndex={tabIndex}
         {...props}
       />
 

--- a/src/range/__tests__/Range.test.tsx
+++ b/src/range/__tests__/Range.test.tsx
@@ -138,4 +138,18 @@ describe('Range', () => {
     fireEvent.click(screen.getByTestId('max-test'));
     expect(handleChange).not.toHaveBeenCalled();
   });
+
+  it('should have a 0 tabIndex value by default', () => {
+    render(<Range min={0} max={100} value={50} />);
+
+    const slider = screen.getByRole('slider');
+    expect(slider.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('should accept tabIndex attribute', () => {
+    render(<Range min={0} max={100} value={50} tabIndex={1} />);
+
+    const slider = screen.getByRole('slider');
+    expect(slider.getAttribute('tabindex')).toBe('1');
+  });
 });

--- a/stories/liveEdit/RangeLive.tsx
+++ b/stories/liveEdit/RangeLive.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
 import { Range } from '../../src/range/Range';
-import {faVolumeDown, faVolumeUp} from "@fortawesome/free-solid-svg-icons";
-
+import { faVolumeDown, faVolumeUp } from '@fortawesome/free-solid-svg-icons';
 
 const RangeDemo = `
 function RangeDemo() {
@@ -35,6 +34,7 @@ function RangeDemo() {
                    </div>
 
                }
+      tabIndex={0}
     />
   );
 }

--- a/stories/range/Documentation.stories.mdx
+++ b/stories/range/Documentation.stories.mdx
@@ -2,14 +2,14 @@ import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
 import { Range } from '../../src/range/Range';
 
 <Meta
-    title="DCXLibrary/Form/Range/documentation"
-    component={Range}
-    parameters={{
-        viewMode: 'docs',
-        previewTabs: {
-            canvas: { hidden: true },
-        },
-    }}
+  title="DCXLibrary/Form/Range/documentation"
+  component={Range}
+  parameters={{
+    viewMode: 'docs',
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+  }}
 />
 
 # Range
@@ -26,24 +26,27 @@ Use the range component when users need to input based on a range of values
 An example with all the available properties is:
 
 ```js
-<Range  min={0}
-        max={100}
-        value={75}
-        inputClass="customRange"
-        disabled={false}
-        showTooltip={true}
-        onChange={setDisplayValue}
-        ariaLabel="rangeComponent"
-        prefix={
-                    <div>
-                        <p1>Low</p1>
-                    </div>
-                }
-        suffix={
-                    <div>
-                        <p1>High</p1>
-                    </div>
-                }/>
+<Range
+  min={0}
+  max={100}
+  value={75}
+  inputClass="customRange"
+  disabled={false}
+  showTooltip={true}
+  onChange={setDisplayValue}
+  ariaLabel="rangeComponent"
+  prefix={
+    <div>
+      <p1>Low</p1>
+    </div>
+  }
+  suffix={
+    <div>
+      <p1>High</p1>
+    </div>
+  }
+  tabIndex={0}
+/>
 ```
 
 <Props of={Range} />


### PR DESCRIPTION
Issue: https://github.com/Capgemini/dcx-react-library/issues/301

Capability to take a tabIndex that can added to the element within the DOM has been added to Progress component.
