### PR TITLE
fix: allow closing of the Autocomplete results list with the Escape key instead of onBlur

### DIFF
--- a/src/autocomplete/Autocomplete.tsx
+++ b/src/autocomplete/Autocomplete.tsx
@@ -377,11 +377,12 @@ export const Autocomplete = ({
         return;
       }
       setActiveOption(activeOption + 1);
+    } else if (evt.code === 'Escape') {
+      setShowOptions(false);
     }
   };
 
   const onBlur = () => {
-    setShowOptions(false);
     setShowPrompt(false);
   };
 

--- a/src/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/src/autocomplete/__tests__/Autocomplete.test.tsx
@@ -519,7 +519,7 @@ describe('Autocomplete', () => {
     expect(formSelect.name).toBe('selectName');
   });
 
-  it('should hide the results list if losing focus', async () => {
+  it('should hide the results list if pressing the Escape key', async () => {
     jest.spyOn(hooks, 'useHydrated').mockImplementation(() => true);
 
     const user = userEvent.setup();
@@ -538,9 +538,7 @@ describe('Autocomplete', () => {
     resultList = screen.queryByRole('list');
     expect(resultList).not.toBeNull();
 
-    act(() => {
-      fireEvent.blur(input);
-    });
+    fireEvent.keyDown(input, { code: 'Escape' });
 
     resultList = screen.queryByRole('list');
     expect(resultList).toBe(null);


### PR DESCRIPTION
- As the `onBlur` on the text input was closing the results list, it was interrupting the click handler for the results list and this was the cause of issue #399 
- The `onBlur` on the text input no longer closes the results list, so clicking outside has no effect anymore.  However, we can now press the `Escape` key to close it.  Will need to come up with a different way of closing the results list if clicking outside

Fixes #399 
