### PR TITLE
Feature/remove testing library react hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@storybook/theming": "^6.5.15",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "13.4.0",
-    "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.4.3",
     "@types/lodash": "4.14.186",
     "@types/mock-fs": "4.13.1",

--- a/src/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/src/autocomplete/__tests__/Autocomplete.test.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Autocomplete, AutoCompleteErrorPosition } from '../';
 import userEvent from '@testing-library/user-event';
-import { act } from '@testing-library/react-hooks';
 import * as hooks from '../../common/utils/clientOnly';
 
 const firstSearch = [

--- a/src/button/__tests__/Button.test.tsx
+++ b/src/button/__tests__/Button.test.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Button } from '../Button';
 import { BUTTON_TYPE } from '..';
 import userEvent from '@testing-library/user-event';
-import { act } from '@testing-library/react-hooks';
 
 const DummyLoadingButton = ({ loadingLabel }: any) => {
   const [isLoading, setIsLoading] = React.useState(false);

--- a/src/common/components/__tests__/Conditional.test.tsx
+++ b/src/common/components/__tests__/Conditional.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Conditional } from '../Conditional';
-import { act } from '@testing-library/react-hooks';
 
 describe('Conditional', () => {
   it('should render a conditional input', () => {

--- a/src/common/utils/__tests__/UseValidation.test.tsx
+++ b/src/common/utils/__tests__/UseValidation.test.tsx
@@ -1,5 +1,5 @@
 import { useValidation, useValidationOnChange } from '../useValidation';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 
 interface Validity {
   rule: any;

--- a/src/multiSelect/components/__test__/Selected.test.tsx
+++ b/src/multiSelect/components/__test__/Selected.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { render, screen, within, fireEvent } from '@testing-library/react';
+import { act, render, screen, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { Selected } from '../Selected';
-import { act } from '@testing-library/react-hooks';
 
 describe('Selected', () => {
   it('should render a selected', () => {

--- a/src/multiSelect/components/__test__/SelectedItem.test.tsx
+++ b/src/multiSelect/components/__test__/SelectedItem.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { SelectedItem } from '../SelectedItem';
-import { act } from '@testing-library/react-hooks';
 
 describe('SelectedItem', () => {
   it('should render a selected item', () => {

--- a/src/progress/Progress.tsx
+++ b/src/progress/Progress.tsx
@@ -40,7 +40,7 @@ export const Progress = ({
   value,
   tabIndex = 0,
 }: ProgressProps) => (
-  <div tabIndex={tabIndex} data-testId={id}>
+  <div tabIndex={tabIndex} data-testid={id}>
     <label className={labelClassName} htmlFor={id}>{`${label}: `}</label>
     <progress id={id} className={className} max={max} value={value}>
       <div id={id} className={className}>

--- a/src/tabGroup/__test__/TabGroup.test.tsx
+++ b/src/tabGroup/__test__/TabGroup.test.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
-import { renderHook } from '@testing-library/react-hooks';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, renderHook } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Tab } from '../components/Tab';
 import { TabGroup } from '../TabGroup';

--- a/src/table/Table.tsx
+++ b/src/table/Table.tsx
@@ -188,7 +188,7 @@ export const Table = ({
   };
 
   return (
-    <div tabIndex={tabIndex} data-testId="table-container">
+    <div tabIndex={tabIndex} data-testid="table-container">
       {withSearch && (
         <input
           onChange={(e: any) => setSearchVal(e.target.value)}

--- a/src/table/__tests__/useSortable.test.tsx
+++ b/src/table/__tests__/useSortable.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { useSortableData } from '../useSortable';
 
 const data = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3354,14 +3354,6 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
-  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    react-error-boundary "^3.1.0"
-
 "@testing-library/react@13.4.0":
   version "13.4.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.4.0.tgz#6a31e3bf5951615593ad984e96b9e5e2d9380966"
@@ -12342,13 +12334,6 @@ react-element-to-jsx-string@^14.3.4:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "17.0.2"
-
-react-error-boundary@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
 
 react-input-autosize@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Issue: https://github.com/Capgemini/dcx-react-library/issues/406

- removed _@testing-library/react-hooks_ package and importing `renderHook` and `act` from _@testing-library/react_

additionally: 
- changed data-testid to correct case as it was also logging an error during running the test files.