### PR TITLE
fix: added error position option for after hint in formInput component

### DIFF
--- a/src/formInput/FormInput.tsx
+++ b/src/formInput/FormInput.tsx
@@ -129,6 +129,7 @@ export enum ErrorPosition {
   BEFORE_LABEL = 'before-label',
   BOTTOM = 'bottom',
   AFTER_LABEL = 'after-label',
+  AFTER_HINT = 'after-hint',
 }
 
 export const FormInput = ({
@@ -242,6 +243,9 @@ export const FormInput = ({
         <ErrorMessage />
       )}
       {hint && hint.position === 'above' && <Hint {...hint} />}
+      {errorPosition && errorPosition === ErrorPosition.AFTER_HINT && (
+        <ErrorMessage />
+      )}
       {prefix || suffix ? (
         <div {...inputDivProps}>
           {prefix && !isEmpty(prefix) && (

--- a/src/formInput/__tests__/FormInput.test.tsx
+++ b/src/formInput/__tests__/FormInput.test.tsx
@@ -417,6 +417,21 @@ describe('FormInput', () => {
     expect(hint.innerHTML).toBe('my hint');
   });
 
+  it('should display the formInput error message after the hint', async () => {
+    const { container } = render(
+      <DummyStaticComponent
+        pos={ErrorPosition.AFTER_HINT}
+        hint={{
+          id: 'my-hint',
+          text: 'my hint',
+        }}
+      />
+    );
+
+    const error: any = container.querySelector('[role=error]');
+    expect(error.innerHTML).toContain('static error message');
+  });
+
   it('should display the aria-label name if the aria-label attribute is not passed', () => {
     const handleChange = jest.fn();
     render(

--- a/stories/Input/Styled.stories.mdx
+++ b/stories/Input/Styled.stories.mdx
@@ -23,7 +23,7 @@ In this section we're using the formInput component providing the GovUk style pa
           value={value}
           onChange={handleChange}
           ariaLabel="standard-input"
-          ariaRequired = "true"
+          ariaRequired="true"
         />
       );
     }}
@@ -48,7 +48,7 @@ In this section we're using the formInput component providing the GovUk style pa
           value={value}
           onChange={handleChange}
           ariaLabel="standard-input"
-          ariaRequired = "true"
+          ariaRequired="true"
           inputDivProps={{}}
         />
       );
@@ -78,7 +78,7 @@ In this section we're using the formInput component providing the GovUk style pa
             content: 'kg',
           }}
           ariaLabel="standard-input-suffix"
-          ariaRequired = "true"
+          ariaRequired="true"
         />
       );
     }}
@@ -107,7 +107,7 @@ In this section we're using the formInput component providing the GovUk style pa
             content: '£',
           }}
           aria-label="standard-input-pre-post-fix"
-          ariaRequired = "true"
+          ariaRequired="true"
         />
       );
     }}
@@ -143,7 +143,7 @@ In this section we're using the formInput component providing the GovUk style pa
             content: '£',
           }}
           aria-label="standard-input-pre-post-fix"
-          ariaRequired = "true"
+          ariaRequired="true"
         />
       );
     }}
@@ -183,7 +183,7 @@ Note: to display the error message type a letter and remove it
           }}
           errorPosition="before-label"
           ariaLabel="standard-input-validation"
-          ariaRequired = "true"
+          ariaRequired="true"
         />
       );
     }}
@@ -212,7 +212,7 @@ Note: to display the error message type a letter and remove it
             className: 'govuk-hint',
           }}
           ariaLabel="standard-input-validation"
-          ariaRequired = "true"
+          ariaRequired="true"
         />
       );
     }}
@@ -235,7 +235,7 @@ Note: to display the error message type a letter and remove it
           type="text"
           value="value"
           ariaLabel="input-with-error"
-          ariaRequired = "true"
+          ariaRequired="true"
           hint={{
             position: 'above',
             text: 'My hint',
@@ -244,7 +244,7 @@ Note: to display the error message type a letter and remove it
           }}
           errorProps={{ className: 'govuk-error-message' }}
           staticErrorMessage="some error appened here"
-          errorPosition="after-label"
+          errorPosition="after-hint"
           containerClassNameError="govuk-form-group--error"
         />
       );


### PR DESCRIPTION
Issue: https://github.com/Capgemini/dcx-react-library/issues/405

added `errorPosition.AFTER_HINT` option for after hint in formInput component