### PR TITLE
use classNames utils

### DIFF
--- a/src/autocomplete/ResultList.tsx
+++ b/src/autocomplete/ResultList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { classNames } from '../common';
+import { classNames, conditionalClassNames } from '../common';
 
 type ResultListProps = {
   list: string[];
@@ -42,16 +42,16 @@ export const ResultList = ({
       ? list.map((optionName: string, index: number) => (
           <li
             id={listId ? `${listId}--${index + 1}` : undefined}
-            className={
-              index === activeOption && activeClass
-                ? [activeClass, liContainerClass].join(' ')
-                : [
-                    liContainerClass,
-                    index % 2 === 0
-                      ? `${liContainerClass}--even`
-                      : `${liContainerClass}--odd`,
-                  ].join(' ')
-            }
+            className={conditionalClassNames([
+              liContainerClass,
+              {
+                [`${activeClass}`]: index === activeOption,
+                [`${liContainerClass}--even`]:
+                  index !== activeOption && index % 2 === 0,
+                [`${liContainerClass}--odd`]:
+                  index !== activeOption && index % 2 !== 0,
+              },
+            ])}
             key={optionName}
             onClick={onClick}
             style={liContainerStyle}

--- a/src/autocomplete/ResultList.tsx
+++ b/src/autocomplete/ResultList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { classNames, conditionalClassNames } from '../common';
+import { classNames } from '../common';
 
 type ResultListProps = {
   list: string[];
@@ -42,7 +42,7 @@ export const ResultList = ({
       ? list.map((optionName: string, index: number) => (
           <li
             id={listId ? `${listId}--${index + 1}` : undefined}
-            className={conditionalClassNames([
+            className={classNames([
               liContainerClass,
               {
                 [`${activeClass}`]: index === activeOption,

--- a/src/autocomplete/ResultList.tsx
+++ b/src/autocomplete/ResultList.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { classNames } from '../common';
 
 type ResultListProps = {
   list: string[];
@@ -59,7 +60,7 @@ export const ResultList = ({
           </li>
         ))
       : noElFoundText && (
-          <li className={[liContainerClass, noOptionClass].join(' ')}>
+          <li className={classNames([liContainerClass, noOptionClass])}>
             {noElFoundText}
           </li>
         )}

--- a/src/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/src/autocomplete/__tests__/Autocomplete.test.tsx
@@ -355,7 +355,7 @@ describe('Autocomplete', () => {
     fireEvent.keyDown(input, { code: 'ArrowUp' });
 
     const listItems: any = screen.getAllByRole('listitem');
-    expect(listItems[0].className).toBe('activeClass ');
+    expect(listItems[0].className).toBe('activeClass');
   });
 
   it('should highlight the last one as active if you try to keyDown', async () => {
@@ -374,7 +374,7 @@ describe('Autocomplete', () => {
     fireEvent.keyDown(input, { code: 'ArrowDown' });
 
     const listItems: any = screen.getAllByRole('listitem');
-    expect(listItems[1].className).toBe('activeClass ');
+    expect(listItems[1].className).toBe('activeClass');
   });
 
   it('should call the selected function after the selection', async () => {

--- a/src/autocomplete/__tests__/ResultList.test.tsx
+++ b/src/autocomplete/__tests__/ResultList.test.tsx
@@ -105,11 +105,13 @@ describe('ResultList', () => {
         activeOption={1}
         onClick={handleClick}
         noOptionClass="noOptionClass"
+        liContainerClass="liContainerClass"
         noElFoundText="nada de nada"
       />
     );
     const el: any = container.querySelector('li');
     expect(el.innerHTML).toBe('nada de nada');
+    expect(el.className).toBe('liContainerClass noOptionClass');
   });
 
   it('should contain the dynamic id for every item in the list if listId is present', () => {

--- a/src/autocomplete/__tests__/ResultList.test.tsx
+++ b/src/autocomplete/__tests__/ResultList.test.tsx
@@ -48,7 +48,7 @@ describe('ResultList', () => {
       <ResultList
         list={['daniele', 'isaac']}
         userInput="d"
-        activeOption={1}
+        activeOption={0}
         onClick={handleClick}
         ulContainerClass="ulContainerClass"
         liContainerClass="liContainerClass"

--- a/src/common/components/__tests__/ErrorMessage.test.tsx
+++ b/src/common/components/__tests__/ErrorMessage.test.tsx
@@ -10,7 +10,7 @@ describe('ErrorMessage', () => {
     expect(screen.getByText('We have a problem')).toBeInTheDocument();
   });
 
-  it('will render an error message with a className and the default dcx-erro-message className', () => {
+  it('will render an error message with a className and the default dcx-error-message className', () => {
     render(<ErrorMessage text="We have a problem" className="my-class-name" />);
 
     expect(screen.getByText('We have a problem').getAttribute('class')).toBe(

--- a/src/common/utils/__tests__/classNames.tsx
+++ b/src/common/utils/__tests__/classNames.tsx
@@ -1,4 +1,4 @@
-import { classNames, conditionalClassNames } from '../classNames';
+import { classNames } from '../classNames';
 
 describe('ClassNames', () => {
   it('should concatenates all the classes', () => {
@@ -15,59 +15,53 @@ describe('ClassNames', () => {
   });
 
   it('should concatenates conditional classes without conditions', () => {
-    expect(conditionalClassNames(['a', 'b', 'c', 'd'])).toBe('a b c d');
+    expect(classNames(['a', 'b', 'c', 'd'])).toBe('a b c d');
   });
 
   it('should skip undefined or null classes in the concatenates function', () => {
-    expect(conditionalClassNames(['a', 'undefined', 'c', 'null'])).toBe('a c');
+    expect(classNames(['a', 'undefined', 'c', 'null'])).toBe('a c');
   });
 
   it('should skip non string parameters in the concatenates function', () => {
     //@ts-ignore
-    expect(conditionalClassNames(['a', undefined, 'c', null])).toBe('a c');
+    expect(classNames(['a', undefined, 'c', null])).toBe('a c');
   });
 
   it('should skip conditional classNames if the value is false', () => {
-    expect(conditionalClassNames(['a', { 'c d': false }, 'd'])).toBe('a d');
+    expect(classNames(['a', { 'c d': false }, 'd'])).toBe('a d');
   });
 
   it('should skip conditional classNames if the value is undefined', () => {
-    expect(conditionalClassNames(['a', { 'c d': undefined }, 'd'])).toBe('a d');
+    expect(classNames(['a', { 'c d': undefined }, 'd'])).toBe('a d');
   });
 
   it('should remove the undefined classNames', () => {
-    expect(conditionalClassNames(['a', { 'c undefined': true }, 'd'])).toBe(
-      'a c d'
-    );
+    expect(classNames(['a', { 'c undefined': true }, 'd'])).toBe('a c d');
   });
 
   it('should skip conditional classNames if the value is null', () => {
-    expect(conditionalClassNames(['a', { 'c d': null }, 'd'])).toBe('a d');
+    expect(classNames(['a', { 'c d': null }, 'd'])).toBe('a d');
   });
 
   it('should add conditional classNames if the value is true', () => {
-    expect(conditionalClassNames(['a', { 'c d': true }, 'b'])).toBe('a c d b');
+    expect(classNames(['a', { 'c d': true }, 'b'])).toBe('a c d b');
   });
 
   it('should loop through the object and concatenate all the values', () => {
-    expect(
-      conditionalClassNames(['a', { 'c d': true, 'e f': true }, 'b'])
-    ).toBe('a c d e f b');
+    expect(classNames(['a', { 'c d': true, 'e f': true }, 'b'])).toBe(
+      'a c d e f b'
+    );
   });
 
   it('should loop through the object and concatenate all the values and filter undefined and null', () => {
     expect(
-      conditionalClassNames(['a', { 'c undefined': true, 'e null': true }, 'b'])
+      classNames(['a', { 'c undefined': true, 'e null': true }, 'b'])
     ).toBe('a c e b');
   });
 
-  it.only('should loop through the object and concatenate all the values and filter undefined and null and the falsy', () => {
+  it('should loop through the object and concatenate all the values and filter undefined and null and the falsy', () => {
     expect(
-      conditionalClassNames([
-        'a',
-        { 'c undefined': false, 'e null': true },
-        'b',
-      ])
+      classNames(['a', { 'c undefined': false, 'e null': true }, 'b'])
     ).toBe('a e b');
   });
 });

--- a/src/common/utils/classNames.ts
+++ b/src/common/utils/classNames.ts
@@ -8,7 +8,8 @@ const classNames = (classes: any[]): string =>
         c !== null &&
         typeof c === 'string'
     )
-    .join(' ');
+    .join(' ')
+    .trim();
 
 const conditionalClassNames = (classes: any[]) => {
   let result = '';
@@ -30,7 +31,7 @@ const conditionalClassNames = (classes: any[]) => {
         result = result.concat(c).concat(' ');
     }
   });
-  return result.slice(0, -1);
+  return result.slice(0, -1).trim();
 };
 
 export { classNames, conditionalClassNames };

--- a/src/common/utils/classNames.ts
+++ b/src/common/utils/classNames.ts
@@ -1,17 +1,4 @@
-const classNames = (classes: any[]): string =>
-  classes
-    .filter(
-      (c: string) =>
-        c !== 'undefined' &&
-        c !== undefined &&
-        c !== 'null' &&
-        c !== null &&
-        typeof c === 'string'
-    )
-    .join(' ')
-    .trim();
-
-const conditionalClassNames = (classes: any[]) => {
+export const classNames = (classes: any[]) => {
   let result = '';
   classes.forEach((c: any) => {
     if (c !== null && typeof c === 'object') {
@@ -33,5 +20,3 @@ const conditionalClassNames = (classes: any[]) => {
   });
   return result.slice(0, -1).trim();
 };
-
-export { classNames, conditionalClassNames };

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -2,4 +2,4 @@ export { useValidation, useValidationOnChange } from './useValidation';
 export { validateDateString } from './validDate';
 export { Roles } from './rolesType';
 export { useHydrated } from './clientOnly';
-export { classNames, conditionalClassNames } from './classNames';
+export { classNames } from './classNames';

--- a/src/details/Details.tsx
+++ b/src/details/Details.tsx
@@ -1,5 +1,5 @@
 import React, { MouseEventHandler, useState } from 'react';
-import { conditionalClassNames } from '../common';
+import { classNames } from '../common';
 
 type DetailsProps = {
   /**
@@ -60,7 +60,7 @@ export const Details = ({
         <span className={summaryTextClassName}>{summary}</span>
       </summary>
       <div
-        className={conditionalClassNames([
+        className={classNames([
           {
             [`${detailsTextClassName}`]: detailsTextClassName !== undefined,
             [`${openClassName || OPEN}`]: isOpen,

--- a/src/details/Details.tsx
+++ b/src/details/Details.tsx
@@ -1,4 +1,5 @@
 import React, { MouseEventHandler, useState } from 'react';
+import { conditionalClassNames } from '../common';
 
 type DetailsProps = {
   /**
@@ -59,9 +60,12 @@ export const Details = ({
         <span className={summaryTextClassName}>{summary}</span>
       </summary>
       <div
-        className={`${
-          detailsTextClassName !== undefined ? detailsTextClassName : ''
-        } ${isOpen === true ? openClassName || OPEN : ''}`.trim()}
+        className={conditionalClassNames([
+          {
+            [`${detailsTextClassName}`]: detailsTextClassName !== undefined,
+            [`${openClassName || OPEN}`]: isOpen,
+          },
+        ])}
       >
         {children}
       </div>

--- a/src/formDate/FormDate.tsx
+++ b/src/formDate/FormDate.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { upperFirst } from 'lodash';
 import { ErrorMessage } from '../common/components';
-import { validateDateString } from '../common/utils';
+import { classNames, validateDateString } from '../common/utils';
 import { DateComponent } from './Date';
 export type DateType = {
   label?: string;
@@ -215,7 +215,7 @@ export const FormDate = ({
             customLabel={yearProps?.customLabel}
             classNameSpan={yearProps?.classNameSpan}
             label={yearProps?.label}
-            classNameInput={[yearProps?.classNameInput, inputClass].join(' ')}
+            classNameInput={classNames([yearProps?.classNameInput, inputClass])}
             disabled={disabled}
           />
         );
@@ -231,7 +231,10 @@ export const FormDate = ({
             customLabel={monthProps?.customLabel}
             classNameSpan={monthProps?.classNameSpan}
             label={monthProps?.label}
-            classNameInput={[monthProps?.classNameInput, inputClass].join(' ')}
+            classNameInput={classNames([
+              monthProps?.classNameInput,
+              inputClass,
+            ])}
             disabled={disabled}
           />
         );
@@ -247,7 +250,7 @@ export const FormDate = ({
             customLabel={dayProps?.customLabel}
             classNameSpan={dayProps?.classNameSpan}
             label={dayProps?.label}
-            classNameInput={[dayProps?.classNameInput, inputClass].join(' ')}
+            classNameInput={classNames([dayProps?.classNameInput, inputClass])}
             disabled={disabled}
           />
         );

--- a/src/formDate/__test__/FormDate.test.tsx
+++ b/src/formDate/__test__/FormDate.test.tsx
@@ -96,6 +96,33 @@ describe('FormInput', () => {
     expect(parent.getAttribute('class')).toBe('containerClass');
   });
 
+  it('should render the correct input classes when provided', () => {
+    const { container } = render(
+      <FormDate
+        dateFormat="dd/mm/yyyy"
+        handleValidity={jest.fn()}
+        inputClass="input"
+        yearProps={{
+          classNameInput: 'year-input',
+        }}
+        monthProps={{
+          classNameInput: 'month-input',
+        }}
+        dayProps={{
+          classNameInput: 'day-input',
+        }}
+      />
+    );
+
+    const year: any = container.querySelector('input[name="year"]');
+    const month: any = container.querySelector('input[name="month"]');
+    const day: any = container.querySelector('input[name="day"]');
+
+    expect(year.getAttribute('class')).toBe('year-input input');
+    expect(month.getAttribute('class')).toBe('month-input input');
+    expect(day.getAttribute('class')).toBe('day-input input');
+  });
+
   it('should render dd/mm/yyyy inputs in the order specified by the user', () => {
     const { container } = render(
       <FormDate dateFormat="dd/mm/yyyy" handleValidity={jest.fn()} />

--- a/src/formInput/FormInput.tsx
+++ b/src/formInput/FormInput.tsx
@@ -5,7 +5,7 @@ import {
   Roles,
   Label,
   Hint,
-  conditionalClassNames,
+  classNames,
 } from '../common';
 import { HintProps } from '../common/components/commonTypes';
 
@@ -232,7 +232,7 @@ export const FormInput = ({
 
   return (
     <div
-      className={conditionalClassNames([
+      className={classNames([
         containerClassName,
         { [`${containerClassNameError}`]: isStaticOrDynamicError() },
       ])}

--- a/src/formInput/FormInput.tsx
+++ b/src/formInput/FormInput.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { isEmpty } from 'lodash';
-import { useValidationOnChange, Roles, Label, Hint } from '../common';
+import {
+  useValidationOnChange,
+  Roles,
+  Label,
+  Hint,
+  conditionalClassNames,
+} from '../common';
 import { HintProps } from '../common/components/commonTypes';
 
 type FormInputProps = {
@@ -226,9 +232,10 @@ export const FormInput = ({
 
   return (
     <div
-      className={`${containerClassName} ${
-        isStaticOrDynamicError() ? containerClassNameError : ''
-      }`.trim()}
+      className={conditionalClassNames([
+        containerClassName,
+        { [`${containerClassNameError}`]: isStaticOrDynamicError() },
+      ])}
     >
       {errorPosition && errorPosition === ErrorPosition.BEFORE_LABEL && (
         <ErrorMessage />

--- a/src/formInput/__tests__/FormInput.test.tsx
+++ b/src/formInput/__tests__/FormInput.test.tsx
@@ -373,9 +373,10 @@ describe('FormInput', () => {
     const { container } = render(
       <DummyStaticComponent pos={ErrorPosition.AFTER_LABEL} />
     );
-    const inputContainer: Element | null =
-      container.querySelector('.container-error');
-    expect(inputContainer).not.toBeNull();
+    const inputContainer: Element | null = container.querySelector('div');
+    expect(inputContainer?.getAttribute('class')).toBe(
+      'container-class container-error'
+    );
   });
 
   it('should add an extra class if the dynamic error is displayed', async () => {

--- a/src/formSelect/FormSelect.tsx
+++ b/src/formSelect/FormSelect.tsx
@@ -6,7 +6,7 @@ import {
   Option,
   Roles,
   Label,
-  conditionalClassNames,
+  classNames,
 } from '../common';
 import {
   ErrorMessageProps,
@@ -193,7 +193,7 @@ export const FormSelect = ({
     if (onChange) onChange(event);
   };
 
-  const containerClasses = conditionalClassNames([
+  const containerClasses = classNames([
     'dcx-formselect',
     containerClassName,
     {

--- a/src/range/Range.tsx
+++ b/src/range/Range.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { conditionalClassNames } from '../common';
 import { Roles } from '../common/utils/rolesType';
 import style from './scrubber.module.css';
 
@@ -118,9 +119,10 @@ export const Range = ({
         value={defaultValue}
         onChange={handleChange}
         disabled={disabled}
-        className={[showTooltip ? style.tooltip : '', inputClass]
-          .join(' ')
-          .trim()}
+        className={conditionalClassNames([
+          inputClass,
+          { [`${style.tooltip}`]: showTooltip },
+        ])}
         aria-label={ariaLabel || 'input-slider'}
         value-tooltip={defaultValue}
         style={styling}

--- a/src/range/Range.tsx
+++ b/src/range/Range.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { conditionalClassNames } from '../common';
+import { classNames } from '../common';
 import { Roles } from '../common/utils/rolesType';
 import style from './scrubber.module.css';
 
@@ -119,7 +119,7 @@ export const Range = ({
         value={defaultValue}
         onChange={handleChange}
         disabled={disabled}
-        className={conditionalClassNames([
+        className={classNames([
           inputClass,
           { [`${style.tooltip}`]: showTooltip },
         ])}

--- a/src/tabGroup/TabGroup.tsx
+++ b/src/tabGroup/TabGroup.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Roles } from '../common';
+import { classNames, Roles } from '../common';
 
 export type TabGroupProps = {
   /**
@@ -144,9 +144,10 @@ export const TabGroup = forwardRef(
             value={{ activeTab, changeActiveTab: onClickHandler }}
           >
             {children.map((child: JSX.Element, index: number) => {
-              const classes: string = [tabClassName, child.props.className]
-                .filter((cls: string) => cls !== undefined)
-                .join(' ');
+              const classes: string = classNames([
+                tabClassName,
+                child.props.className,
+              ]);
 
               return (
                 <child.type
@@ -174,9 +175,7 @@ export const TabGroup = forwardRef(
             >
               {tab.props.children}
             </div>
-          ) : (
-            undefined
-          )
+          ) : undefined
         )}
       </div>
     );

--- a/src/tabGroup/components/Tab.tsx
+++ b/src/tabGroup/components/Tab.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { conditionalClassNames, Roles } from '../../common';
+import { classNames, Roles } from '../../common';
 import { useTabGroup } from '../TabGroup';
 
 export type TabProps = {
@@ -55,7 +55,7 @@ export const Tab = ({
 
   const selected = activeTab === eventKey;
 
-  const classes: string = conditionalClassNames([
+  const classes: string = classNames([
     className,
     {
       [`${activeTabClassName}`]: selected,

--- a/src/tabGroup/components/Tab.tsx
+++ b/src/tabGroup/components/Tab.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Roles } from '../../common';
+import { conditionalClassNames, Roles } from '../../common';
 import { useTabGroup } from '../TabGroup';
 
 export type TabProps = {
@@ -54,14 +54,14 @@ export const Tab = ({
   const { activeTab, changeActiveTab } = useTabGroup();
 
   const selected = activeTab === eventKey;
-  const classes: string = [
+
+  const classes: string = conditionalClassNames([
     className,
-    selected ? activeTabClassName : undefined,
-    disabled ? disabledClassName : undefined,
-  ]
-    .filter((cls: string | undefined) => cls !== undefined)
-    .join(' ')
-    .trim();
+    {
+      [`${activeTabClassName}`]: selected,
+      [`${disabledClassName}`]: disabled,
+    },
+  ]);
 
   const onClickHandler: (
     event:

--- a/src/table/Body.tsx
+++ b/src/table/Body.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { omit } from 'lodash';
 import { Row } from './Row';
+import { conditionalClassNames } from '../common';
 
 const rowValues = (dataSource: any, columnsToOmit?: string[]): any[] =>
   Object.values(omit(omit(dataSource, ['trProps']), columnsToOmit || []));
@@ -46,12 +47,14 @@ export const Body = ({
     <tbody className={tbodyClassName}>
       {combineValueWithTrProps.map((v: any, key: number) => (
         <Row
-          onSelect={v => handleSelected(v, key)}
+          onSelect={(v) => handleSelected(v, key)}
           handleCellClick={handleCellClick}
-          trClassName={[
+          trClassName={conditionalClassNames([
             trClassName,
-            selected === key ? selectedRowClassName : undefined,
-          ].join(' ')}
+            {
+              [`${selectedRowClassName}`]: selected === key,
+            },
+          ])}
           tdClassName={tdClassName}
           key={key}
           values={rowValues(v, columnsToOmit)}

--- a/src/table/Body.tsx
+++ b/src/table/Body.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { omit } from 'lodash';
 import { Row } from './Row';
-import { conditionalClassNames } from '../common';
+import { classNames } from '../common';
 
 const rowValues = (dataSource: any, columnsToOmit?: string[]): any[] =>
   Object.values(omit(omit(dataSource, ['trProps']), columnsToOmit || []));
@@ -49,7 +49,7 @@ export const Body = ({
         <Row
           onSelect={(v) => handleSelected(v, key)}
           handleCellClick={handleCellClick}
-          trClassName={conditionalClassNames([
+          trClassName={classNames([
             trClassName,
             {
               [`${selectedRowClassName}`]: selected === key,

--- a/src/toggle/Toggle.tsx
+++ b/src/toggle/Toggle.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { classNames, conditionalClassNames } from '../common';
 import style from './toggle.module.css';
 
 interface ToggleProps {
@@ -70,10 +71,13 @@ export const Toggle = ({
         cursor: disabled ? 'not-allowed' : 'pointer',
         filter: disabled ? 'brightness(0.9)' : 'unset',
       }}
-      className={`${style.switch} ${className || ''}`}
+      className={classNames([style.switch, className])}
     >
       <div
-        className={`${style.switchBg} ${checked ? style.isChecked : ''}`}
+        className={conditionalClassNames([
+          style.switchBg,
+          { [`${style.isChecked}`]: checked },
+        ])}
         style={{
           backgroundColor: checked ? onColor : offColor,
           borderRadius: borderRadius || '34px',
@@ -101,7 +105,10 @@ export const Toggle = ({
       <div
         id="dragswitch-handle"
         title="dragswitch-handle"
-        className={`${style.switchHandle} ${checked ? style.isChecked : ''}`}
+        className={conditionalClassNames([
+          style.switchHandle,
+          { [`${style.isChecked}`]: checked },
+        ])}
         style={{
           WebkitTransition: 'transform .2s',
           MozTransition: 'transform .2s',

--- a/src/toggle/Toggle.tsx
+++ b/src/toggle/Toggle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { classNames, conditionalClassNames } from '../common';
+import { classNames } from '../common';
 import style from './toggle.module.css';
 
 interface ToggleProps {
@@ -74,7 +74,7 @@ export const Toggle = ({
       className={classNames([style.switch, className])}
     >
       <div
-        className={conditionalClassNames([
+        className={classNames([
           style.switchBg,
           { [`${style.isChecked}`]: checked },
         ])}
@@ -105,7 +105,7 @@ export const Toggle = ({
       <div
         id="dragswitch-handle"
         title="dragswitch-handle"
-        className={conditionalClassNames([
+        className={classNames([
           style.switchHandle,
           { [`${style.isChecked}`]: checked },
         ])}

--- a/src/tooltip/Tooltip.tsx
+++ b/src/tooltip/Tooltip.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { classNames } from '../common';
 import style from './tooltip.module.css';
 
 type Direction = 'top' | 'bottom' | 'left' | 'right';
@@ -76,9 +77,11 @@ export const ToolTip = ({
       {props.children}
       {active && (
         <div
-          className={[style.tooltip, className, containerClassDirection()].join(
-            ' '
-          )}
+          className={classNames([
+            style.tooltip,
+            className,
+            containerClassDirection(),
+          ])}
           style={{
             color: color,
             background: background,


### PR DESCRIPTION
Issue: https://github.com/Capgemini/dcx-react-library/issues/407

- small change to classNames and conditionalClassNames: added .trim() to both
- scanned all components and replaced .join(' ') and conditionals for class names with the new classNames and conditionalClassNames util functions
- added/amended some tests where appropriate