### PR TITLE
Feature/storybook deprecated plugin

### DIFF
--- a/stories/Autocomplete/Documentation-server.stories.mdx
+++ b/stories/Autocomplete/Documentation-server.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Autocomplete } from '../../src/autocomplete/Autocomplete';
 
 <Meta

--- a/stories/Autocomplete/Documentation.stories.mdx
+++ b/stories/Autocomplete/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Autocomplete } from '../../src/autocomplete/Autocomplete';
 
 <Meta

--- a/stories/Autocomplete/Live.stories.mdx
+++ b/stories/Autocomplete/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Autocomplete } from '../../src/autocomplete/Autocomplete';
 import AutocompleteLive from '../liveEdit/AutocompleteLive';
 

--- a/stories/Autocomplete/Styled.stories.mdx
+++ b/stories/Autocomplete/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Autocomplete } from '../../src/autocomplete/Autocomplete';
 import './style.css';
 

--- a/stories/Autocomplete/UnStyled.stories.mdx
+++ b/stories/Autocomplete/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Autocomplete } from '../../src/autocomplete/Autocomplete';
 
 <Meta title="DCXLibrary/Form/Autocomplete/Unstyled" component={Autocomplete} />

--- a/stories/Button/Documentation.stories.mdx
+++ b/stories/Button/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Button } from '../../src/button/Button';
 
 <Meta

--- a/stories/Button/Live.stories.mdx
+++ b/stories/Button/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Button } from '../../src/button/Button';
 import ButtonLive from '../liveEdit/ButtonLive';
 

--- a/stories/Button/Styled.stories.mdx
+++ b/stories/Button/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Button } from '../../src/button/Button';
 
 <Meta 

--- a/stories/Button/UnStyled.stories.mdx
+++ b/stories/Button/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Button } from '../../src/button/Button';
 
 <Meta title="DCXLibrary/Form/Button" component={Button} />

--- a/stories/CharacterCount/Documentation.stories.mdx
+++ b/stories/CharacterCount/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { CharacterCount } from '../../src/characterCount';
 
 <Meta

--- a/stories/CharacterCount/Live.stories.mdx
+++ b/stories/CharacterCount/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { CharacterCount } from '../../src/characterCount';
 import CharacterCountLive from '../liveEdit/CharacterCountLive';
 

--- a/stories/CharacterCount/Syled.stories.mdx
+++ b/stories/CharacterCount/Syled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { CharacterCount } from '../../src/characterCount';
 
 <Meta

--- a/stories/CharacterCount/UnStyled.stories.mdx
+++ b/stories/CharacterCount/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { CharacterCount } from '../../src/characterCount';
 
 <Meta title="DCXLibrary/Form/CharacterCount" component={CharacterCount} />

--- a/stories/CheckboxGroup/Documentation.stories.mdx
+++ b/stories/CheckboxGroup/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { CheckboxGroup } from '../../src/checkboxGroup/CheckboxGroup';
 
 <Meta

--- a/stories/CheckboxGroup/Live.stories.mdx
+++ b/stories/CheckboxGroup/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { CheckboxGroup } from '../../src/checkboxGroup/CheckboxGroup';
 import CheckboxGroupLive from '../liveEdit/CheckboxGroupLive';
 

--- a/stories/CheckboxGroup/Styled.stories.mdx
+++ b/stories/CheckboxGroup/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { CheckboxGroup } from '../../src/checkboxGroup/CheckboxGroup';
 
 <Meta title="DCXLibrary/Form/checkboxGroup/Styled" component={CheckboxGroup} />

--- a/stories/CheckboxGroup/UnStyled.stories.mdx
+++ b/stories/CheckboxGroup/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { CheckboxGroup } from '../../src/checkboxGroup/CheckboxGroup';
 
 <Meta title="DCXLibrary/Form/CheckboxGroup" component={CheckboxGroup} />

--- a/stories/CopyToClipboard/Documentation.stories.mdx
+++ b/stories/CopyToClipboard/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { CopyToClipboard } from '../../src/copyToClipboard/CopyToClipboard';
 
 <Meta

--- a/stories/CopyToClipboard/Live.stories.mdx
+++ b/stories/CopyToClipboard/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { CopyToClipboard } from '../../src/copyToClipboard/CopyToClipboard';
 import CopyToClipboardLive from '../liveEdit/CopyToClipboardLive';
 

--- a/stories/CopyToClipboard/Styled.stories.mdx
+++ b/stories/CopyToClipboard/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { CopyToClipboard } from '../../src/copyToClipboard/CopyToClipboard';
 import './style.css';
 

--- a/stories/CopyToClipboard/UnStyled.stories.mdx
+++ b/stories/CopyToClipboard/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { CopyToClipboard } from '../../src/copyToClipboard/CopyToClipboard';
 
 <Meta title="DCXLibrary/CopyToClipboard" component={CopyToClipboard}/>

--- a/stories/Details/Documentation.stories.mdx
+++ b/stories/Details/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Details } from '../../src/details/Details';
 
 <Meta

--- a/stories/Details/Live.stories.mdx
+++ b/stories/Details/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Details } from '../../src/details/Details';
 import DetailsLive from '../liveEdit/DetailsLive';
 

--- a/stories/Details/Styled.stories.mdx
+++ b/stories/Details/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Details } from '../../src/details/Details';
 
 <Meta title="DCXLibrary/Details/Styled" component={Details} />

--- a/stories/Details/UnStyled.stories.mdx
+++ b/stories/Details/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Details } from '../../src/details/Details';
 import { Table } from '../../src/table/Table';
 

--- a/stories/FormCheckbox/Documentation.stories.mdx
+++ b/stories/FormCheckbox/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormCheckbox } from '../../src/formCheckbox/FormCheckbox';
 
 <Meta

--- a/stories/FormCheckbox/Live.stories.mdx
+++ b/stories/FormCheckbox/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormCheckbox } from '../../src/formCheckbox/FormCheckbox';
 import FormCheckboxLive from '../liveEdit/FormCheckboxLive';
 

--- a/stories/FormCheckbox/Styled.stories.mdx
+++ b/stories/FormCheckbox/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormCheckbox } from '../../src/formCheckbox/FormCheckbox';
 
 <Meta title="DCXLibrary/Form/Checkbox/Styled" component={FormCheckbox} />

--- a/stories/FormCheckbox/UnStyled.stories.mdx
+++ b/stories/FormCheckbox/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormCheckbox } from '../../src/formCheckbox/FormCheckbox';
 
 <Meta title="DCXLibrary/Form/Checkbox" component={FormCheckbox} />

--- a/stories/FormDate/Documentation.stories.mdx
+++ b/stories/FormDate/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormDate } from '../../src/formDate/FormDate';
 
 <Meta

--- a/stories/FormDate/Live.stories.mdx
+++ b/stories/FormDate/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormDate } from '../../src/formDate/FormDate';
 import FormDateLive from '../liveEdit/FormDateLive';
 

--- a/stories/FormDate/Styled.stories.mdx
+++ b/stories/FormDate/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormDate } from '../../src/formDate/FormDate';
 
 <Meta title="DCXLibrary/Form/Date/Styled" component={FormDate} />

--- a/stories/FormDate/UnStyled.stories.mdx
+++ b/stories/FormDate/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormDate } from '../../src/formDate/FormDate';
 
 <Meta title="DCXLibrary/Form/Date" component={FormDate} />

--- a/stories/FormSelect/Documentation.stories.mdx
+++ b/stories/FormSelect/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormSelect } from '../../src/formSelect/FormSelect';
 
 <Meta

--- a/stories/FormSelect/Live.stories.mdx
+++ b/stories/FormSelect/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormSelect } from '../../src/formSelect/FormSelect';
 import FormSelectLive from '../liveEdit/FormSelectLive';
 

--- a/stories/FormSelect/Styled.stories.mdx
+++ b/stories/FormSelect/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormSelect } from '../../src/formSelect/FormSelect';
 
 <Meta title="DCXLibrary/Form/Select/Styled" component={FormSelect} />

--- a/stories/FormSelect/UnStyled.stories.mdx
+++ b/stories/FormSelect/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormSelect } from '../../src/formSelect/FormSelect';
 
 <Meta title="DCXLibrary/Form/Select" component={FormSelect} />

--- a/stories/Input/Documentation.stories.mdx
+++ b/stories/Input/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormInput } from '../../src/formInput/FormInput';
 
 <Meta

--- a/stories/Input/Live.stories.mdx
+++ b/stories/Input/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormInput } from '../../src/formInput/FormInput';
 import FormInputLive from '../liveEdit/FormInputLive';
 

--- a/stories/Input/Styled.stories.mdx
+++ b/stories/Input/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormInput } from '../../src/formInput/FormInput';
 
 <Meta title="DCXLibrary/Form/Input/Styled" component={FormInput} />

--- a/stories/Input/UnStyled.stories.mdx
+++ b/stories/Input/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormInput } from '../../src/formInput/FormInput';
 
 <Meta title="DCXLibrary/Form/Input" component={FormInput} />

--- a/stories/InputMask/Live.stories.mdx
+++ b/stories/InputMask/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormInputMasked } from '../../src/formInput/FormInputMasked';
 import FormInputMaskedLive from '../liveEdit/FormInputMaskedLive';
 

--- a/stories/InputMask/Styled.stories.mdx
+++ b/stories/InputMask/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormInputMasked } from '../../src/formInput/FormInputMasked';
 
 <Meta title="DCXLibrary/Form/InputMasked/Styled" component={FormInputMasked} />

--- a/stories/InputMask/UnStyled.stories.mdx
+++ b/stories/InputMask/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormInputMasked } from '../../src/formInput/FormInputMasked';
 
 <Meta title="DCXLibrary/Form/InputMasked" component={FormInputMasked} />

--- a/stories/MultiSelect/Documentation.stories.mdx
+++ b/stories/MultiSelect/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { MultiSelect } from '../../src/multiSelect/MultiSelect';
 
 <Meta

--- a/stories/MultiSelect/Live.stories.mdx
+++ b/stories/MultiSelect/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { MultiSelect } from '../../src/multiSelect/MultiSelect';
 import MultiSelectLive from '../liveEdit/MultiSelectLive';
 

--- a/stories/MultiSelect/Styled.stories.mdx
+++ b/stories/MultiSelect/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { MultiSelect } from '../../src/multiSelect/MultiSelect';
 
 <Meta title="DCXLibrary/Form/MultiSelect/Styled" component={MultiSelect} />

--- a/stories/MultiSelect/UnStyled.stories.mdx
+++ b/stories/MultiSelect/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { MultiSelect } from '../../src/multiSelect/MultiSelect';
 
 <Meta title="DCXLibrary/Form/MultiSelect" component={MultiSelect} />

--- a/stories/MultiUpload/Documentation.stories.mdx
+++ b/stories/MultiUpload/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { MultiUpload } from '../../src/multiUpload/MultiUpload';
 
 <Meta

--- a/stories/MultiUpload/Live.stories.mdx
+++ b/stories/MultiUpload/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { MultiUpload } from '../../src/multiUpload/MultiUpload';
 import MultiUploadLive from '../liveEdit/MultiUploadLive';
 

--- a/stories/MultiUpload/Styled.stories.mdx
+++ b/stories/MultiUpload/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { MultiUpload } from '../../src/multiUpload/MultiUpload';
 
 <Meta title="DCXLibrary/Form/MultiUpload/Styled" component={MultiUpload} />

--- a/stories/MultiUpload/UnStyled.stories.mdx
+++ b/stories/MultiUpload/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { MultiUpload } from '../../src/multiUpload/MultiUpload';
 
 <Meta title="DCXLibrary/Form/MultiUpload" component={MultiUpload} />

--- a/stories/RadioGroup/Documentation.stories.mdx
+++ b/stories/RadioGroup/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { RadioGroup } from '../../src/radioGroup/RadioGroup';
 
 <Meta

--- a/stories/RadioGroup/Live.stories.mdx
+++ b/stories/RadioGroup/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { RadioGroup } from '../../src/radioGroup/RadioGroup';
 import RadioGroupLive from '../liveEdit/RadioGroupLive';
 

--- a/stories/RadioGroup/Styled.stories.mdx
+++ b/stories/RadioGroup/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { RadioGroup } from '../../src/radioGroup/RadioGroup';
 
 <Meta title="DCXLibrary/Form/RadioGroup/Styled" component={RadioGroup} />

--- a/stories/RadioGroup/UnStyled.stories.mdx
+++ b/stories/RadioGroup/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { RadioGroup } from '../../src/radioGroup/RadioGroup';
 
 <Meta title="DCXLibrary/Form/RadioGroup" component={RadioGroup} />

--- a/stories/TabGroup/Documentation.stories.mdx
+++ b/stories/TabGroup/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { TabGroup } from '../../src/tabGroup/TabGroup';
 import { Tab } from '../../src/tabGroup/components/Tab';
 

--- a/stories/TabGroup/Live.stories.mdx
+++ b/stories/TabGroup/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { TabGroup } from '../../src/tabGroup/TabGroup';
 import { Tab } from '../../src/tabGroup/components/Tab';
 import TabGroupLive from '../liveEdit/TabGroupLive';

--- a/stories/TabGroup/Styled.stories.mdx
+++ b/stories/TabGroup/Styled.stories.mdx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Button } from '../../src/button/Button';
 import { TabGroup } from '../../src/tabGroup/TabGroup';
 import { Tab } from '../../src/tabGroup/components/Tab';

--- a/stories/TabGroup/UnStyled.stories.mdx
+++ b/stories/TabGroup/UnStyled.stories.mdx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Button } from '../../src/button/Button';
 import { TabGroup } from '../../src/tabGroup/TabGroup';
 import { Tab } from '../../src/tabGroup/components/Tab';

--- a/stories/Utils/Documentation.stories.mdx
+++ b/stories/Utils/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 
 <Meta
   title="DCXLibrary/Utils/classNames"

--- a/stories/introduction.stories.mdx
+++ b/stories/introduction.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { FormInput } from '../src/formInput/FormInput';
 
 

--- a/stories/progress/Documentation.stories.mdx
+++ b/stories/progress/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Progress } from '../../src/progress/Progress';
 
 <Meta

--- a/stories/progress/Live.stories.mdx
+++ b/stories/progress/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Progress } from '../../src/progress/Progress';
 import ProgressLive from '../liveEdit/ProgressLive';
 

--- a/stories/progress/Styled.stories.mdx
+++ b/stories/progress/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Progress } from '../../src/progress/Progress';
 import './style.css';
 

--- a/stories/progress/UnStyled.stories.mdx
+++ b/stories/progress/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Progress } from '../../src/progress/Progress';
 
 <Meta title="DCXLibrary/Form/Progress" component={Progress} />

--- a/stories/range/Documentation.stories.mdx
+++ b/stories/range/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Range } from '../../src/range/Range';
 
 <Meta

--- a/stories/range/Live.stories.mdx
+++ b/stories/range/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Range } from '../../src/range/Range';
 import RangeLive from '../liveEdit/RangeLive';
 

--- a/stories/range/Styled.stories.mdx
+++ b/stories/range/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Range } from '../../src/range/Range';
 import './style.css';
 

--- a/stories/range/UnStyled.stories.mdx
+++ b/stories/range/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Range } from '../../src/range/Range';
 
 <Meta title="DCXLibrary/Form/Range" component={Range} />

--- a/stories/table/Documentation.stories.mdx
+++ b/stories/table/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Table } from '../../src/table/Table';
 
 <Meta

--- a/stories/table/Live.stories.mdx
+++ b/stories/table/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Table } from '../../src/table/Table';
 import TableLive from '../liveEdit/TableLive';
 

--- a/stories/table/Styled.stories.mdx
+++ b/stories/table/Styled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Table } from '../../src/table/Table';
 import './tableStyle.css';
 

--- a/stories/table/UnStyled.stories.mdx
+++ b/stories/table/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Table } from '../../src/table/Table';
 
 <Meta title="DCXLibrary/Table" component={Table} />

--- a/stories/toggle/Documentation.stories.mdx
+++ b/stories/toggle/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Toggle } from '../../src/toggle/Toggle';
 
 <Meta

--- a/stories/toggle/Live.stories.mdx
+++ b/stories/toggle/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Toggle } from '../../src/toggle/Toggle';
 import ToggleLive from '../liveEdit/ToggleLive';
 

--- a/stories/toggle/UnStyled.stories.mdx
+++ b/stories/toggle/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { Toggle } from '../../src/toggle/Toggle';
 
 <Meta title="DCXLibrary/Form/Toggle" component={Toggle} />

--- a/stories/toolTip/Documentation.stories.mdx
+++ b/stories/toolTip/Documentation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { ToolTip } from '../../src/tooltip/Tooltip';
 
 <Meta

--- a/stories/toolTip/Live.stories.mdx
+++ b/stories/toolTip/Live.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { ToolTip } from '../../src/tooltip/Tooltip';
 import ToolTipLive from '../liveEdit/ToolTipLive';
 

--- a/stories/toolTip/UnStyled.stories.mdx
+++ b/stories/toolTip/UnStyled.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Props } from '@storybook/addon-docs';
 import { ToolTip } from '../../src/tooltip/Tooltip';
 
 <Meta title="DCXLibrary/Form/ToolTip" component={ToolTip} />


### PR DESCRIPTION
Issue : 413
Deprecating @storybook/addon-docs/blocks in favor of @storybook/addon-docs to resolve the warning while running storybook.
Documentation : https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-scoped-blocks-imports
Expected Result : No warning message related to deprecated plugin.