### PR TITLE
fix: reset character count on focus

### DIFF
--- a/example/src/components/CharacterCountDemo.tsx
+++ b/example/src/components/CharacterCountDemo.tsx
@@ -3,10 +3,9 @@ import { Button, CharacterCount } from '@capgeminiuk/dcx-react-library';
 
 export const CharacterCountDemo = () => {
   const textRef = useRef<any>(null);
-  const [txtValue, setTxtValue] = React.useState<string>('');
+  const [value, setValue] = React.useState<string>('');
   const edit = () => {
-    console.log('im in the edit action');
-    setTxtValue('Arpana');
+    setValue('prefill value');
   };
 
   return (
@@ -22,12 +21,46 @@ export const CharacterCountDemo = () => {
           rows={5}
           cols={50}
           ref={textRef}
-          value={txtValue}
-          onChange={(evt) => setTxtValue(evt.currentTarget.value)}
+          value={value}
+          onChange={(evt) => setValue(evt.currentTarget.value)}
         />
         <Button onClick={() => textRef.current.reset()} label="Cancel" />
         <Button onClick={edit} label="edit" />
       </form>
+
+      <h2>Constrained</h2>
+      <CharacterCount
+        label="Label for text area"
+        hint={{
+          text: 'Type more than 15 characters to see the limitation',
+        }}
+        maxLength={15}
+        constrained={true}
+        rows={5}
+        cols={50}
+      />
+      <h2>Threshold</h2>
+      <CharacterCount
+        label="Label for text area"
+        hint={{
+          text: 'Type more than 12 characters to see the message',
+        }}
+        maxLength={15}
+        threshold={80}
+        rows={5}
+        cols={50}
+      />
+      <h2>Word Count</h2>
+      <CharacterCount
+        label="Label for text area"
+        hint={{
+          text: 'Type more than 15 words to see the message change',
+        }}
+        maxLength={15}
+        limitType="words"
+        rows={5}
+        cols={50}
+      />
     </>
   );
 };

--- a/example/src/components/CharacterCountDemo.tsx
+++ b/example/src/components/CharacterCountDemo.tsx
@@ -1,20 +1,29 @@
-import React from 'react';
-import { CharacterCount } from '@capgeminiuk/dcx-react-library';
+import React, { useRef } from 'react';
+import { Button, CharacterCount } from '@capgeminiuk/dcx-react-library';
 
 export const CharacterCountDemo = () => {
+  const textRef = useRef<any>(null);
+
   return (
     <>
       <h1>Character Count Component</h1>
       <h2>Basic</h2>
-      <CharacterCount
-        label="Label for text area"
-        hint={{
-          text: 'Type more than 15 characters to see the message change',
-        }}
-        maxLength={15}
-        rows={5}
-        cols={50}
-      />
+      <>
+        <form>
+          <CharacterCount
+            label="Label for text area"
+            hint={{
+              text: 'Type more than 15 characters to see the message change',
+            }}
+            maxLength={15}
+            rows={5}
+            cols={50}
+            ref={textRef}
+          />
+          <Button onClick={() => textRef.current.reset()} label="Cancel" />
+        </form>
+      </>
+
       <h2>Constrained</h2>
       <CharacterCount
         label="Label for text area"

--- a/example/src/components/CharacterCountDemo.tsx
+++ b/example/src/components/CharacterCountDemo.tsx
@@ -3,60 +3,31 @@ import { Button, CharacterCount } from '@capgeminiuk/dcx-react-library';
 
 export const CharacterCountDemo = () => {
   const textRef = useRef<any>(null);
+  const [txtValue, setTxtValue] = React.useState<string>('');
+  const edit = () => {
+    console.log('im in the edit action');
+    setTxtValue('Arpana');
+  };
 
   return (
     <>
       <h1>Character Count Component</h1>
-      <h2>Basic</h2>
-      <>
-        <form>
-          <CharacterCount
-            label="Label for text area"
-            hint={{
-              text: 'Type more than 15 characters to see the message change',
-            }}
-            maxLength={15}
-            rows={5}
-            cols={50}
-            ref={textRef}
-          />
-          <Button onClick={() => textRef.current.reset()} label="Cancel" />
-        </form>
-      </>
-
-      <h2>Constrained</h2>
-      <CharacterCount
-        label="Label for text area"
-        hint={{
-          text: 'Type more than 15 characters to see the limitation',
-        }}
-        maxLength={15}
-        constrained={true}
-        rows={5}
-        cols={50}
-      />
-      <h2>Threshold</h2>
-      <CharacterCount
-        label="Label for text area"
-        hint={{
-          text: 'Type more than 12 characters to see the message',
-        }}
-        maxLength={15}
-        threshold={80}
-        rows={5}
-        cols={50}
-      />
-      <h2>Word Count</h2>
-      <CharacterCount
-        label="Label for text area"
-        hint={{
-          text: 'Type more than 15 words to see the message change',
-        }}
-        maxLength={15}
-        limitType="words"
-        rows={5}
-        cols={50}
-      />
+      <form style={{ padding: '10px' }}>
+        <CharacterCount
+          label="Label for text area"
+          hint={{
+            text: 'Type more than 15 characters to see the message change',
+          }}
+          maxLength={15}
+          rows={5}
+          cols={50}
+          ref={textRef}
+          value={txtValue}
+          onChange={(evt) => setTxtValue(evt.currentTarget.value)}
+        />
+        <Button onClick={() => textRef.current.reset()} label="Cancel" />
+        <Button onClick={edit} label="edit" />
+      </form>
     </>
   );
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@capgeminiuk/dcx-react-library",
   "author": "Capgemini UK",
   "license": "MIT",
-  "version": "0.7.0-alpha-10",
+  "version": "0.7.0-alpha-15",
   "source": "src/index.ts",
   "main": "dist/dcx-react-library.js",
   "module": "dist/dcx-react-library.module.js",

--- a/src/characterCount/CharacterCount.tsx
+++ b/src/characterCount/CharacterCount.tsx
@@ -203,6 +203,7 @@ export const CharacterCount = ({
           cols={cols}
           maxLength={constrained && !isWordsCount ? maxLength : undefined}
           aria-describedby={ariaDescribedBy || ''}
+          onFocus={handleChange}
           {...props}
         />
         {showMessage && (

--- a/src/characterCount/CharacterCount.tsx
+++ b/src/characterCount/CharacterCount.tsx
@@ -3,6 +3,7 @@ import React, {
   useEffect,
   useImperativeHandle,
   forwardRef,
+  RefObject,
 } from 'react';
 import { classNames, ErrorMessage, useHydrated } from '../common';
 import { HintProps, VisuallyHidden } from '../common/components/commonTypes';
@@ -118,8 +119,11 @@ type CharacterCountProps = React.HTMLAttributes<HTMLTextAreaElement> & {
   ) => string;
   /**
    * will allow to expose the reset function to clear textbox and reset the component;
+   * @example
+   * const textRef = useRef<any>(null);
+   * <Button onClick={() => textRef.current.reset()} label="Cancel" />
    */
-  ref?: any;
+  ref?: RefObject<any>;
 };
 
 export const CharacterCount = forwardRef(
@@ -175,6 +179,15 @@ export const CharacterCount = forwardRef(
         ? (value.split(' ').length / maxLength) * 100 >= threshold
         : threshold && (value.length / maxLength) * 100 >= threshold;
 
+    const calcRemainingCount = (value: string) => {
+      const remaining = getRemaining(value);
+      const overThreshold = isOverThreshold(value);
+
+      setShowMessage(overThreshold || !threshold);
+      if (remaining < 0) setOverLimitBy(-remaining);
+      setRemainingCount(remaining);
+    };
+
     useEffect(() => {
       setShowError(displayError);
     }, [displayError]);
@@ -184,12 +197,7 @@ export const CharacterCount = forwardRef(
     }, [value]);
 
     useEffect(() => {
-      const remaining = getRemaining(textareaValue);
-      const overThreshold = isOverThreshold(textareaValue);
-
-      setShowMessage(overThreshold || !threshold);
-      if (remaining < 0) setOverLimitBy(-remaining);
-      setRemainingCount(remaining);
+      calcRemainingCount(textareaValue);
     }, [textareaValue]);
 
     const reset = () => {
@@ -205,12 +213,8 @@ export const CharacterCount = forwardRef(
     }));
 
     const handleChange = (evt: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const remaining = getRemaining(evt.target.value);
-      const overThreshold = isOverThreshold(evt.target.value);
+      calcRemainingCount(evt.target.value);
 
-      setShowMessage(overThreshold || !threshold);
-      setOverLimitBy(-remaining);
-      setRemainingCount(remaining);
       setTextareaValue(evt.target.value);
 
       onChange && onChange(evt);
@@ -254,8 +258,8 @@ export const CharacterCount = forwardRef(
             onFocus={handleChange}
             onReset={handleChange}
             ref={ref}
-            {...props}
             value={textareaValue}
+            {...props}
           />
           {showMessage && (
             <div

--- a/src/characterCount/CharacterCount.tsx
+++ b/src/characterCount/CharacterCount.tsx
@@ -113,7 +113,7 @@ type CharacterCountProps = React.HTMLAttributes<HTMLTextAreaElement> & {
     hydrated?: boolean
   ) => string;
   /**
-   *
+   * will allow to expose the reset function to clear textbox and reset the component;
    */
   ref?: any;
 };

--- a/src/characterCount/CharacterCount.tsx
+++ b/src/characterCount/CharacterCount.tsx
@@ -180,13 +180,17 @@ export const CharacterCount = forwardRef(
     }, [displayError]);
 
     useEffect(() => {
+      setTextareaValue(value);
+    }, [value]);
+
+    useEffect(() => {
       const remaining = getRemaining(textareaValue);
       const overThreshold = isOverThreshold(textareaValue);
 
       setShowMessage(overThreshold || !threshold);
       if (remaining < 0) setOverLimitBy(-remaining);
       setRemainingCount(remaining);
-    }, []);
+    }, [textareaValue]);
 
     const reset = () => {
       setRemainingCount(maxLength);

--- a/src/characterCount/__tests__/CharacterCount.test.tsx
+++ b/src/characterCount/__tests__/CharacterCount.test.tsx
@@ -310,4 +310,21 @@ describe('CharacterCount with character limit', () => {
       screen.getByText('this is a custom message with 15 and 0')
     ).toBeInTheDocument();
   });
+
+  it('should call given on focus handler when focused', () => {
+    const onFocusHandler = jest.fn();
+
+    render(
+      <CharacterCount
+        onFocus={onFocusHandler}
+        label="Label for text area"
+        maxLength={15}
+        cols={30}
+        rows={5}
+      />
+    );
+
+    screen.getByRole('textbox').focus();
+    expect(onFocusHandler).toHaveBeenCalled();
+  });
 });

--- a/src/characterCount/__tests__/CharacterCount.test.tsx
+++ b/src/characterCount/__tests__/CharacterCount.test.tsx
@@ -330,6 +330,27 @@ describe('CharacterCount with character limit', () => {
     ).toBeInTheDocument();
   });
 
+  it('should allow to specify a custom max character message when there is a value passed in and it is over the limit', () => {
+    render(
+      <CharacterCount
+        label="Label for text area"
+        maxLength={15}
+        cols={30}
+        rows={5}
+        messageClassName="message"
+        customMaxCharMsgFunc={(remainingCount, overLimitBy) =>
+          `this is a custom message with ${remainingCount} and ${overLimitBy}`
+        }
+        value="This text is more than 15 characters"
+      />
+    );
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(
+      screen.getByText('this is a custom message with -21 and 21')
+    ).toBeInTheDocument();
+  });
+
   it('should reset textfield and message when textarea is reset', async () => {
     const user = userEvent.setup();
 
@@ -345,6 +366,28 @@ describe('CharacterCount with character limit', () => {
     expect(textarea.value).toBe('');
     expect(
       screen.getByText('You can enter up to 15 characters.')
+    ).toBeInTheDocument();
+  });
+
+  it('should show correct message when there is an existing text value', () => {
+    jest.spyOn(hooks, 'useHydrated').mockImplementation(() => true);
+
+    render(
+      <CharacterCount
+        label="Label for text area"
+        maxLength={15}
+        cols={30}
+        rows={5}
+        messageClassName="message"
+        value="hello"
+      />
+    );
+
+    const textarea: any = screen.getByRole('textbox');
+
+    expect(textarea.value).toBe('hello');
+    expect(
+      screen.getByText('You have 10 characters remaining')
     ).toBeInTheDocument();
   });
 });

--- a/src/characterCount/__tests__/CharacterCount.test.tsx
+++ b/src/characterCount/__tests__/CharacterCount.test.tsx
@@ -1,9 +1,28 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { CharacterCount } from '../CharacterCount';
 import userEvent from '@testing-library/user-event';
 import * as hooks from '../../common/utils/clientOnly';
+
+const DummyResetCharacterCountComponent = () => {
+  const textRef = useRef<any>(null);
+  return (
+    <form>
+      <CharacterCount
+        label="Label for text area"
+        hint={{
+          text: 'Type more than 15 characters to see the message change',
+        }}
+        maxLength={15}
+        rows={5}
+        cols={50}
+        ref={textRef}
+      />
+      <button onClick={() => textRef.current.reset()}>Cancel</button>
+    </form>
+  );
+};
 
 describe('CharacterCount with character limit', () => {
   it('should render', () => {
@@ -311,20 +330,21 @@ describe('CharacterCount with character limit', () => {
     ).toBeInTheDocument();
   });
 
-  it('should call given on focus handler when focused', () => {
-    const onFocusHandler = jest.fn();
+  it('should reset textfield and message when textarea is reset', async () => {
+    const user = userEvent.setup();
 
-    render(
-      <CharacterCount
-        onFocus={onFocusHandler}
-        label="Label for text area"
-        maxLength={15}
-        cols={30}
-        rows={5}
-      />
-    );
+    render(<DummyResetCharacterCountComponent />);
 
-    screen.getByRole('textbox').focus();
-    expect(onFocusHandler).toHaveBeenCalled();
+    const button = screen.getByRole('button');
+    const textarea: any = screen.getByRole('textbox');
+
+    await user.type(textarea, 'ab');
+
+    await user.click(button);
+
+    expect(textarea.value).toBe('');
+    expect(
+      screen.getByText('You can enter up to 15 characters.')
+    ).toBeInTheDocument();
   });
 });

--- a/stories/CharacterCount/Documentation.stories.mdx
+++ b/stories/CharacterCount/Documentation.stories.mdx
@@ -56,7 +56,34 @@ An example with all the available properties is:
   customMaxCharMsgFunc={(remainingCount, overLimitBy, hydrated) =>
     `this is a custom message with ${remainingCount} and ${overLimitBy} with js enabled ${hydrated}`
   }
+  ref={textRef}
 />
+```
+
+### Resetting the component
+
+If you want to use a button to clear the textarea and reset the component, you can do this with calling the reset function which can be exposed with a **ref**.
+Create a ref to pass in to the CharacterCount component with React's **useRef** hook.
+For the button that you want to use to clear the text and messages, call the CharacterCount component's exposed **reset()** function, accessing it through the ref e.g. `() => textRef.current.reset()`.
+
+An example for resetting the component with a button:
+
+```js
+const textRef = useRef(null);
+
+<form>
+  <CharacterCount
+    label="Label for text area"
+    hint={{
+      text: 'Type more than 15 characters to see the message change',
+    }}
+    maxLength={15}
+    rows={5}
+    cols={50}
+    ref={textRef}
+  />
+  <button onClick={() => textRef.current.reset()}>Cancel</button>
+</form>;
 ```
 
 <Props of={CharacterCount} />


### PR DESCRIPTION
Issue: https://github.com/Capgemini/dcx-react-library/issues/437

Character count is reset on focus. So after the textarea has been cleared programmatically, and then the textarea is focussed, the counter and the message will be reset to the correct value.

_This is not the perfect solution as the count and message is not updated on clicking the button that clears the form._