### PR TITLE
Feature/autocomplete update value

### DIFF
--- a/src/autocomplete/Autocomplete.tsx
+++ b/src/autocomplete/Autocomplete.tsx
@@ -366,10 +366,10 @@ export const Autocomplete = ({
     }
   }, [options, onChange]);
 
-  React.useEffect(() => {
-    setUserInput(defaultValue);
-  }, [defaultValue]);
-  
+  // React.useEffect(() => {
+  //   setUserInput(defaultValue);
+  // }, [defaultValue]);
+
   const handleClick = (evt: React.FormEvent<HTMLInputElement>) => {
     setActiveOption(0);
     setFilterList([]);

--- a/src/autocomplete/Autocomplete.tsx
+++ b/src/autocomplete/Autocomplete.tsx
@@ -366,6 +366,10 @@ export const Autocomplete = ({
     }
   }, [options, onChange]);
 
+  React.useEffect(() => {
+    setUserInput(defaultValue);
+  }, [defaultValue]);
+  
   const handleClick = (evt: React.FormEvent<HTMLInputElement>) => {
     setActiveOption(0);
     setFilterList([]);

--- a/src/autocomplete/Autocomplete.tsx
+++ b/src/autocomplete/Autocomplete.tsx
@@ -366,9 +366,9 @@ export const Autocomplete = ({
     }
   }, [options, onChange]);
 
-  // React.useEffect(() => {
-  //   setUserInput(defaultValue);
-  // }, [defaultValue]);
+  React.useEffect(() => {
+    setUserInput(defaultValue);
+  }, [defaultValue]);
 
   const handleClick = (evt: React.FormEvent<HTMLInputElement>) => {
     setActiveOption(0);

--- a/src/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/src/autocomplete/__tests__/Autocomplete.test.tsx
@@ -237,6 +237,21 @@ describe('Autocomplete', () => {
     expect(input).toBeInTheDocument();
   });
 
+  it('When defaultValue prop is changed, Autocomplete component updates.', () => {
+    const defaultValue: string = 'initial value';
+    const updatedValue: string = 'updated value';
+  
+    const { getByRole, rerender } = render(<Autocomplete options={['first', 'second']} defaultValue={defaultValue} />);
+  
+    const inputElement: any = getByRole('textbox');
+    expect(inputElement.value).toBe(defaultValue);
+  
+    // Trigger a change in defaultValue
+    rerender(<Autocomplete options={['first', 'second']} defaultValue={updatedValue} />);
+    const updatedInputElement: any = getByRole('textbox');
+    expect(updatedInputElement.value).toBe(updatedValue);
+  });
+  
   it('should display available options', async () => {
     const user = userEvent.setup();
 

--- a/src/autocomplete/__tests__/Autocomplete.test.tsx
+++ b/src/autocomplete/__tests__/Autocomplete.test.tsx
@@ -237,21 +237,39 @@ describe('Autocomplete', () => {
     expect(input).toBeInTheDocument();
   });
 
-  it('When defaultValue prop is changed, Autocomplete component updates.', () => {
-    const defaultValue: string = 'initial value';
-    const updatedValue: string = 'updated value';
+  it('When defaultValue prop is changed, Autocomplete component updates.', async () => {
+    const DummyChangeState = () => {
+      const [defaultValue, setDefaultValue] = React.useState('Apple');
+      const handleClick = (value: string) => {
+        setDefaultValue(value);
+      };
+      return (
+        <>
+          <Autocomplete
+            options={['Apple', 'Banana']}
+            defaultValue={defaultValue}
+            onSelected={value => handleClick(value)}
+          />
+          <button onClick={() => handleClick('Orange')}>Orange</button>
+        </>
+      );
+    };
   
-    const { getByRole, rerender } = render(<Autocomplete options={['first', 'second']} defaultValue={defaultValue} />);
-  
-    const inputElement: any = getByRole('textbox');
-    expect(inputElement.value).toBe(defaultValue);
-  
-    // Trigger a change in defaultValue
-    rerender(<Autocomplete options={['first', 'second']} defaultValue={updatedValue} />);
-    const updatedInputElement: any = getByRole('textbox');
-    expect(updatedInputElement.value).toBe(updatedValue);
+    render(<DummyChangeState />);
+    await act(async () => {
+      await waitFor(() => {
+        const input: any = screen.getByRole('textbox');
+        expect(input.value).toBe('Apple');
+      });
+    });
+    const button = screen.getByRole('button');
+    userEvent.click(button);
+    await waitFor(() => {
+      const input: any = screen.getByRole('textbox');
+      expect(input.value).toBe('Orange');
+    }); 
   });
-  
+
   it('should display available options', async () => {
     const user = userEvent.setup();
 
@@ -846,7 +864,9 @@ describe('Autocomplete', () => {
       return options
         .filter(
           (option: any) =>
-            optionName(option).toLowerCase().indexOf(queryStr) !== -1
+            optionName(option)
+              .toLowerCase()
+              .indexOf(queryStr) !== -1
         )
         .map((option: any) => {
           const commonRank = 0;


### PR DESCRIPTION
This fix addresses an issue (https://github.com/Capgemini/dcx-react-library/issues/462) where the `Autocomplete` component was not updating when the `defaultValue` prop was changed. 

By this fix, whenever the `defaultValue` prop changes, the component will re-render, and the input element will correctly display the updated `defaultValue`.

It includes the test. 
I have commented out the fix in order to intentionally see the test failing. Once I have confirmed that the test is failing as expected, then I uncommented the fix and verified that the test passes as intended.

