### PR TITLE
updated the button component to better render aria-label

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@capgeminiuk/dcx-react-library",
   "author": "Capgemini UK",
   "license": "MIT",
-  "version": "1.0.0-rc-3",
+  "version": "1.0.0-rc-4",
   "source": "src/index.ts",
   "main": "dist/dcx-react-library.js",
   "module": "dist/dcx-react-library.module.js",

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -87,7 +87,7 @@ export const Button = ({
   onClick,
   type = BUTTON_TYPE.BUTTON,
   disabled = false,
-  ariaLabel = `${type}-button`,
+  ariaLabel = `${label}`,
   disableClickForMs,
   customPrefixImg,
   customPostfixImg,
@@ -161,7 +161,7 @@ export const Button = ({
       onClick={handleClick}
       disabled={disable}
       type={type}
-      {...(label ? {} : { 'aria-label': ariaLabel })}
+      aria-label={ariaLabel}
       formAction={formAction}
       name={name}
       className={btnClassName}

--- a/src/button/__tests__/Button.test.tsx
+++ b/src/button/__tests__/Button.test.tsx
@@ -231,23 +231,6 @@ describe('Button', () => {
     expect(button.getAttribute('value')).toBe('buttonValue');
   });
 
-  it('should not render aria-label if label omitted', () => {
-    render(
-      <>
-        <Button label="buttonValue" />
-        <Button type={BUTTON_TYPE.BUTTON} />
-        <Button type={BUTTON_TYPE.SUBMIT} />
-        <Button type={BUTTON_TYPE.RESET} />
-      </>
-    );
-    const buttons: any = screen.getAllByRole('button');
-
-    expect(buttons[0].getAttribute('aria-label')).toBeNull();
-    expect(buttons[1].getAttribute('aria-label')).toBe('button-button');
-    expect(buttons[2].getAttribute('aria-label')).toBe('submit-button');
-    expect(buttons[3].getAttribute('aria-label')).toBe('reset-button');
-  });
-
   it('should render the default className dcx-button', () => {
     const handleClick = jest.fn();
     render(<Button onClick={handleClick} label="Register" />);
@@ -319,5 +302,14 @@ describe('Button', () => {
     expect(() => render(<Button label="test">Children test</Button>)).toThrow(
       'You can use label or children but not both at the same time'
     );
+  });
+  
+  it('should accept ariaLabel as attribute', () => {
+    const handleClick = jest.fn();
+    render(
+      <Button onClick={handleClick} ariaLabel="Register" label="Register" />
+    );
+    const button: any = screen.getByRole('button');
+    expect(button.getAttribute('aria-label')).toBe('Register');
   });
 });

--- a/src/button/__tests__/Button.test.tsx
+++ b/src/button/__tests__/Button.test.tsx
@@ -311,7 +311,7 @@ describe('Button', () => {
     expect(button.getAttribute('aria-label')).toBe('Register');
   });
 
-  it('should render the correct aria-;abel if the attribute is defined', () => {
+  it('should render the provided aria-label if the attribute is defined', () => {
     const handleClick = jest.fn();
     render(
       <Button onClick={handleClick} ariaLabel="Registers" label="Register" />

--- a/src/button/__tests__/Button.test.tsx
+++ b/src/button/__tests__/Button.test.tsx
@@ -5,6 +5,7 @@ import {
   render,
   screen,
   waitFor,
+  cleanup,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Button } from '../Button';
@@ -303,13 +304,17 @@ describe('Button', () => {
       'You can use label or children but not both at the same time'
     );
   });
-  
-  it('should accept ariaLabel as attribute', () => {
+
+  it('should have the correct aria-label', () => {
     const handleClick = jest.fn();
-    render(
-      <Button onClick={handleClick} ariaLabel="Register" label="Register" />
-    );
-    const button: any = screen.getByRole('button');
+    render(<Button onClick={handleClick} label="Register" />);
+    let button: any = screen.getByRole('button');
     expect(button.getAttribute('aria-label')).toBe('Register');
+    cleanup();
+    render(
+      <Button onClick={handleClick} ariaLabel="Registers" label="Register" />
+    );
+    button = screen.getByRole('button');
+    expect(button.getAttribute('aria-label')).toBe('Registers');
   });
 });

--- a/src/button/__tests__/Button.test.tsx
+++ b/src/button/__tests__/Button.test.tsx
@@ -5,7 +5,6 @@ import {
   render,
   screen,
   waitFor,
-  cleanup,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Button } from '../Button';
@@ -305,16 +304,19 @@ describe('Button', () => {
     );
   });
 
-  it('should have the correct aria-label', () => {
+  it('should default the aria-label to the label attribute if not defined', () => {
     const handleClick = jest.fn();
     render(<Button onClick={handleClick} label="Register" />);
-    let button: any = screen.getByRole('button');
+    const button: any = screen.getByRole('button');
     expect(button.getAttribute('aria-label')).toBe('Register');
-    cleanup();
+  });
+
+  it('should render the correct aria-;abel if the attribute is defined', () => {
+    const handleClick = jest.fn();
     render(
       <Button onClick={handleClick} ariaLabel="Registers" label="Register" />
     );
-    button = screen.getByRole('button');
+    const button: any = screen.getByRole('button');
     expect(button.getAttribute('aria-label')).toBe('Registers');
   });
 });


### PR DESCRIPTION
Fixes how the aria label was being rendered by the button component
https://github.com/Capgemini/dcx-react-library/issues/618

* The aria-label should default to the label if not specified as voice activation users won't know what type of button it is or that it has "-button" added afterwards.
* The aria-label attribute should always be rendered if a value is given, it doesn't make sense to hide it if the label property is being used.