### PR TITLE
fix: accessbility removing tabIndex

### DIFF
--- a/src/tabGroup/components/Tab.tsx
+++ b/src/tabGroup/components/Tab.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { classNames, Roles } from '../../common';
+import { classNames, Roles, useHydrated } from '../../common';
 import { useTabGroup } from '../TabGroup';
 
 export type TabProps = {
@@ -73,6 +73,14 @@ export const Tab = ({
       | React.TouchEvent<HTMLAnchorElement>
   ) => changeActiveTab(event.currentTarget.dataset.tabId as string);
 
+  const hydrated = useHydrated();
+  let tabIndex;
+
+  // we don't want to set tab index if it is not hydrated - accessibility requirement
+  if (hydrated) {
+    tabIndex = !selected ? -1 : 0;
+  }
+
   return (
     <li role={Roles.presentation} className={classes}>
       <a
@@ -81,7 +89,7 @@ export const Tab = ({
         className={linkClassName}
         aria-controls={ariaControls}
         aria-selected={selected}
-        tabIndex={!selected ? -1 : 0}
+        tabIndex={tabIndex}
         onClick={!disabled ? onClickHandler : undefined}
         href={`#${eventKey}`}
       >

--- a/src/tabGroup/components/__test__/Tab.test.tsx
+++ b/src/tabGroup/components/__test__/Tab.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Tab } from '../Tab';
 import { TabContext } from '../../TabGroup';
+import * as hooks from '../../../common/utils/clientOnly';
 
 describe('Tab', () => {
   it('should not render a tab with out a context', () => {
@@ -233,5 +234,25 @@ describe('Tab', () => {
 
     expect(onClickHandler).toBeCalled();
     expect(onClickHandler).toBeCalledWith('tab 1');
+  });
+
+  it('should not have the tabIndex property if js is disabled', () => {
+    //@ts-ignore
+    jest.spyOn(hooks, 'useHydrated').mockImplementation(() => false);
+
+    const onClickHandler = jest.fn();
+
+    render(
+      <TabContext.Provider
+        value={{
+          activeTab: 'tab 1',
+          changeActiveTab: onClickHandler,
+        }}
+      >
+        <Tab eventKey="tab 2" label="tab 2" activeTabClassName="tabActive" />
+      </TabContext.Provider>
+    );
+
+    expect(screen.getByRole('tab').getAttribute('tabIndex')).toBeNull();
   });
 });


### PR DESCRIPTION
we don't want to set tab index if it is when JS is disabled - accessibility requirement