### PR TITLE
fix: removing empty alert / error div for a formInput without an error

### DIFF
--- a/src/common/utils/rolesType.ts
+++ b/src/common/utils/rolesType.ts
@@ -1,4 +1,5 @@
 export const Roles = {
+  alert: 'alert',
   button: 'button',
   combobox: 'combobox',
   error: 'error',

--- a/src/formInput/FormInput.tsx
+++ b/src/formInput/FormInput.tsx
@@ -203,6 +203,9 @@ export const FormInput = ({
     if (onBlur) onBlur(event);
   };
 
+  const isStaticMessageValid = (): boolean =>
+    typeof staticErrorMessage === 'string' && !isEmpty(staticErrorMessage);
+
   const ErrorMessage = () => (
     <div
       {...{
@@ -210,12 +213,12 @@ export const FormInput = ({
         className: classNames(['dcx-error-message', errorProps?.className]),
       }}
     >
-      {staticErrorMessage !== undefined ? (
-        <div role={Roles.error} {...errorMessage}>
+      {isStaticMessageValid() ? (
+        <div role={Roles.alert} {...errorMessage}>
           {staticErrorMessage}
         </div>
       ) : validity && !validity.valid && showError ? (
-        <div role={Roles.error} {...errorMessage}>
+        <div role={Roles.alert} {...errorMessage}>
           {validity.message}
         </div>
       ) : null}
@@ -223,7 +226,7 @@ export const FormInput = ({
   );
 
   const isStaticOrDynamicError = (): boolean =>
-    staticErrorMessage !== undefined || (validity && !validity.valid) || false;
+    isStaticMessageValid() || (validity && !validity.valid) || false;
 
   const inputEl: JSX.Element = (
     <input

--- a/src/formInput/__tests__/FormInput.test.tsx
+++ b/src/formInput/__tests__/FormInput.test.tsx
@@ -317,7 +317,6 @@ describe('FormInput', () => {
         inputClassName="inputClass"
         inputProps={{
           defaultValue: 'default value',
-          id: 'userReference',
         }}
         hint={{
           position: 'above',
@@ -348,7 +347,6 @@ describe('FormInput', () => {
         inputClassName="inputClass"
         inputProps={{
           defaultValue: 'default value',
-          id: 'userReference',
         }}
         hint={{
           position: 'above',

--- a/src/formInput/__tests__/FormInput.test.tsx
+++ b/src/formInput/__tests__/FormInput.test.tsx
@@ -323,7 +323,6 @@ describe('FormInput', () => {
           text: 'hint',
           className: 'hint-class',
         }}
-        aria-label="standard-input-validation"
         errorProps={{
           className: '',
         }}
@@ -353,7 +352,6 @@ describe('FormInput', () => {
           text: 'hint',
           className: 'hint-class',
         }}
-        aria-label="standard-input-validation"
         errorProps={{
           className: '',
         }}

--- a/src/formInput/__tests__/FormInput.test.tsx
+++ b/src/formInput/__tests__/FormInput.test.tsx
@@ -149,7 +149,7 @@ describe('FormInput', () => {
     expect(input).toBeInTheDocument();
   });
 
-  it('should have the ariarequrired attribute', () => {
+  it('should have the required aria attribute', () => {
     render(
       <FormInput
         name="password"
@@ -307,12 +307,73 @@ describe('FormInput', () => {
     expect(screen.getByLabelText('this is a label')).toBeInTheDocument();
   });
 
+  it('should not render the formInput with an alert', () => {
+    const { container } = render(
+      <FormInput
+        containerClassName="container"
+        label="label"
+        name="name"
+        type="text"
+        inputClassName="inputClass"
+        inputProps={{
+          defaultValue: 'default value',
+          id: 'userReference',
+        }}
+        hint={{
+          position: 'above',
+          text: 'hint',
+          className: 'hint-class',
+        }}
+        aria-label="standard-input-validation"
+        errorProps={{
+          className: '',
+        }}
+        //@ts-ignore
+        staticErrorMessage={}
+        errorPosition={ErrorPosition.AFTER_LABEL}
+        containerClassNameError=""
+      />
+    );
+
+    expect(container.querySelector('[role=alert]')).not.toBeInTheDocument();
+  });
+
+  it('should not render the formInput with an alert for an empty staticErrorMessage', () => {
+    const { container } = render(
+      <FormInput
+        containerClassName="container"
+        label="label"
+        name="name"
+        type="text"
+        inputClassName="inputClass"
+        inputProps={{
+          defaultValue: 'default value',
+          id: 'userReference',
+        }}
+        hint={{
+          position: 'above',
+          text: 'hint',
+          className: 'hint-class',
+        }}
+        aria-label="standard-input-validation"
+        errorProps={{
+          className: '',
+        }}
+        staticErrorMessage=""
+        errorPosition={ErrorPosition.AFTER_LABEL}
+        containerClassNameError=""
+      />
+    );
+
+    expect(container.querySelector('[role=alert]')).not.toBeInTheDocument();
+  });
+
   it('should display the formInput error', async () => {
     const user = userEvent.setup();
     render(<DummyComponent pos={ErrorPosition.BOTTOM} />);
     const input = screen.getByRole('textbox');
     await user.type(input, 'TEST VALUE');
-    expect(screen.getByRole('error')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
   });
 
   it('should display the formInput error message', async () => {
@@ -320,7 +381,7 @@ describe('FormInput', () => {
     render(<DummyComponent pos={ErrorPosition.BOTTOM} />);
     const input = screen.getByRole('textbox');
     await user.type(input, 'TEST VALUE');
-    expect(screen.getByRole('error')).toContainHTML('is invalid');
+    expect(screen.getByRole('alert')).toContainHTML('is invalid');
   });
 
   it('should display the formInput error message on top', async () => {
@@ -359,7 +420,7 @@ describe('FormInput', () => {
 
   it('should display the error message on load', () => {
     render(<DummyComponent pos={ErrorPosition.BOTTOM} displayError={true} />);
-    expect(screen.getByRole('error')).toContainHTML('is invalid');
+    expect(screen.getByRole('alert')).toContainHTML('is invalid');
   });
 
   it('should display wrapper label container in floating variant', () => {
@@ -404,12 +465,12 @@ describe('FormInput', () => {
     );
     const button = screen.getByRole('button');
     await user.click(button);
-    expect(screen.getByRole('error')).toContainHTML('is invalid');
+    expect(screen.getByRole('alert')).toContainHTML('is invalid');
   });
 
   it('should display a static error message', () => {
     render(<DummyStaticComponent pos={ErrorPosition.AFTER_LABEL} />);
-    const error = screen.getByRole('error');
+    const error = screen.getByRole('alert');
     expect(error.textContent).toBe('static error message');
   });
 
@@ -515,7 +576,7 @@ describe('FormInput', () => {
       />
     );
 
-    const error: any = container.querySelector('[role=error]');
+    const error: any = container.querySelector('[role=alert]');
     expect(error.innerHTML).toContain('static error message');
   });
 


### PR DESCRIPTION
FormInput
- [x] aria-role for error message is now `alert` in order to aid screen readers
- [x] error message element is now rendered only when an error message is present 