### PR TITLE
fix: removing unnecessary div from error message

### DIFF
--- a/example/src/components/FormInputDemo.tsx
+++ b/example/src/components/FormInputDemo.tsx
@@ -30,6 +30,7 @@ export const FormInputDemo = () => {
         inputProps={{
           placeholder: 'enter your email',
         }}
+        hiddenErrorText=""
       />
       <h1>Label</h1>
       <FormInput
@@ -44,6 +45,7 @@ export const FormInputDemo = () => {
         labelProps={{
           htmlFor: 'input-id',
         }}
+        hiddenErrorText=""
       />
       <h1>Prefix</h1>
       <FormInput
@@ -63,6 +65,7 @@ export const FormInputDemo = () => {
           },
           content: <FontAwesomeIcon icon={faAt} />,
         }}
+        hiddenErrorText=""
       />
       <h1>Prefix Label</h1>
       <FormInput
@@ -87,6 +90,7 @@ export const FormInputDemo = () => {
           },
           content: <FontAwesomeIcon icon={faAt} />,
         }}
+        hiddenErrorText=""
       />
       <h1>Suffix</h1>
       <FormInput
@@ -106,6 +110,7 @@ export const FormInputDemo = () => {
           },
           content: <FontAwesomeIcon icon={faAt} />,
         }}
+        hiddenErrorText=""
       />
       <h1>Prefix and suffix</h1>
       <FormInput
@@ -134,6 +139,7 @@ export const FormInputDemo = () => {
           },
           content: <FontAwesomeIcon icon={faAt} />,
         }}
+        hiddenErrorText=""
       />
       <h1>Prefix and suffix with label</h1>
       <FormInput
@@ -166,6 +172,7 @@ export const FormInputDemo = () => {
         labelProps={{
           htmlFor: 'input-id',
         }}
+        hiddenErrorText=""
       />
       <h1>Validation</h1>
       <FormInput
@@ -210,6 +217,7 @@ export const FormInputDemo = () => {
           },
           content: <FontAwesomeIcon icon={faAt} />,
         }}
+        hiddenErrorText=""
       />
       <div>isValid:{showValid.toString()}</div>
     </>

--- a/example/src/components/FormInputDemo.tsx
+++ b/example/src/components/FormInputDemo.tsx
@@ -39,7 +39,6 @@ export const FormInputDemo = () => {
         onChange={handleChange}
         inputProps={{
           placeholder: 'enter your email',
-          htmlFor: 'input-id',
         }}
         label="this is a label"
         labelProps={{

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@capgeminiuk/dcx-react-library",
   "author": "Capgemini UK",
   "license": "MIT",
-  "version": "1.0.0-rc-4",
+  "version": "1.0.0-rc5",
   "source": "src/index.ts",
   "main": "dist/dcx-react-library.js",
   "module": "dist/dcx-react-library.module.js",

--- a/src/autocomplete/Autocomplete.tsx
+++ b/src/autocomplete/Autocomplete.tsx
@@ -515,6 +515,7 @@ export const Autocomplete = ({
           'aria-activedescendant': getActivedescendantId(),
         }}
         tabIndex={tabIndex}
+        hiddenErrorText=""
       />
       {showPrompt && (
         <div className={promptClassName} id={promptId}>

--- a/src/design-system/form-input.css
+++ b/src/design-system/form-input.css
@@ -107,6 +107,8 @@
     font-size: token('font-formcontrol_error-size');
     line-height: token('font-formcontrol_error-line-height');
     color: token('color-text-formcontrol_error');
+    margin-block-start: 0;
+    margin-block-end: 0;
   }
 
   & .dcx-form-input__suffix {

--- a/src/formInput/FormInput.tsx
+++ b/src/formInput/FormInput.tsx
@@ -132,6 +132,14 @@ type FormInputProps = {
    * if a variant floating is specified it will add a class 'dcx-floating-label' for supporting a floating label feature
    */
   variant?: 'floating' | 'floating-filled' | 'normal';
+  /**
+   * visually hidden text for screen readers
+   */
+  hiddenErrorText?: string;
+  /**
+   * visually hidden span attributes
+   */
+  hiddenErrorTextProps?: React.HTMLAttributes<HTMLSpanElement>;
 };
 
 const floatVariants = ['floating', 'floating-filled'];
@@ -172,6 +180,8 @@ export const FormInput = ({
   variant = 'normal',
   inputDivProps = { style: { display: 'flex' } },
   tabIndex = 0,
+  hiddenErrorText,
+  hiddenErrorTextProps,
 }: FormInputProps) => {
   const { validity, onValueChange } = useValidationOnChange(validation, value);
 
@@ -206,8 +216,19 @@ export const FormInput = ({
 
   const ErrorMessage = () => {
     if (isStaticMessageValid()) {
-      return (
-        <div
+      return hiddenErrorText ? (
+        <p
+          {...{
+            ...errorProps,
+            className: classNames(['dcx-error-message', errorProps?.className]),
+            role: Roles.alert,
+          }}
+        >
+          <span {...hiddenErrorTextProps}>{hiddenErrorText}</span>{' '}
+          {staticErrorMessage}
+        </p>
+      ) : (
+        <p
           {...{
             ...errorProps,
             className: classNames(['dcx-error-message', errorProps?.className]),
@@ -215,13 +236,13 @@ export const FormInput = ({
           }}
         >
           {staticErrorMessage}
-        </div>
+        </p>
       );
     }
 
     if (validity && !validity.valid && showError) {
       return (
-        <div
+        <p
           {...{
             ...errorProps,
             className: classNames(['dcx-error-message', errorProps?.className]),
@@ -229,7 +250,7 @@ export const FormInput = ({
           }}
         >
           {validity.message}
-        </div>
+        </p>
       );
     }
 

--- a/src/formInput/FormInput.tsx
+++ b/src/formInput/FormInput.tsx
@@ -220,7 +220,6 @@ export const FormInput = ({
         <p
           {...{
             ...errorProps,
-            className: classNames(['dcx-error-message', errorProps?.className]),
             role: Roles.alert,
           }}
         >
@@ -228,7 +227,7 @@ export const FormInput = ({
           {staticErrorMessage}
         </p>
       ) : (
-        <p
+        <div
           {...{
             ...errorProps,
             className: classNames(['dcx-error-message', errorProps?.className]),
@@ -236,13 +235,13 @@ export const FormInput = ({
           }}
         >
           {staticErrorMessage}
-        </p>
+        </div>
       );
     }
 
     if (validity && !validity.valid && showError) {
       return (
-        <p
+        <div
           {...{
             ...errorProps,
             className: classNames(['dcx-error-message', errorProps?.className]),
@@ -250,7 +249,7 @@ export const FormInput = ({
           }}
         >
           {validity.message}
-        </p>
+        </div>
       );
     }
 

--- a/src/formInput/FormInput.tsx
+++ b/src/formInput/FormInput.tsx
@@ -49,7 +49,7 @@ type FormInputProps = {
   /**
    * allow to customise the error message with all the properites needed
    **/
-  errorProps?: any;
+  errorProps?: React.AllHTMLAttributes<HTMLDivElement>;
   /**
    * allow to customise the input with all the properites needed
    **/
@@ -96,10 +96,6 @@ type FormInputProps = {
    * function that will check if is vald or not based on the validation rules
    **/
   isValid?: (valid: boolean, errorMessageVisible?: boolean) => void;
-  /**
-   * error message
-   **/
-  errorMessage?: any;
   /**
    * allow to specify an error message coming from another source
    */
@@ -162,7 +158,6 @@ export const FormInput = ({
   onFocus,
   onBlur,
   isValid,
-  errorMessage,
   staticErrorMessage,
   errorPosition,
   ariaLabel,
@@ -209,24 +204,37 @@ export const FormInput = ({
   const isStaticMessageValid = (): boolean =>
     typeof staticErrorMessage === 'string' && !isEmpty(staticErrorMessage);
 
-  const ErrorMessage = () => (
-    <div
-      {...{
-        ...errorProps,
-        className: classNames(['dcx-error-message', errorProps?.className]),
-      }}
-    >
-      {isStaticMessageValid() ? (
-        <div role={Roles.alert} {...errorMessage}>
+  const ErrorMessage = () => {
+    if (isStaticMessageValid()) {
+      return (
+        <div
+          {...{
+            ...errorProps,
+            className: classNames(['dcx-error-message', errorProps?.className]),
+            role: Roles.alert,
+          }}
+        >
           {staticErrorMessage}
         </div>
-      ) : validity && !validity.valid && showError ? (
-        <div role={Roles.alert} {...errorMessage}>
+      );
+    }
+
+    if (validity && !validity.valid && showError) {
+      return (
+        <div
+          {...{
+            ...errorProps,
+            className: classNames(['dcx-error-message', errorProps?.className]),
+            role: Roles.alert,
+          }}
+        >
           {validity.message}
         </div>
-      ) : null}
-    </div>
-  );
+      );
+    }
+
+    return null;
+  };
 
   const isStaticOrDynamicError = (): boolean =>
     isStaticMessageValid() || (validity && !validity.valid) || false;

--- a/src/formInput/FormInput.tsx
+++ b/src/formInput/FormInput.tsx
@@ -135,7 +135,7 @@ type FormInputProps = {
   /**
    * visually hidden text for screen readers
    */
-  hiddenErrorText?: string;
+  hiddenErrorText: string;
   /**
    * visually hidden span attributes
    */
@@ -180,7 +180,7 @@ export const FormInput = ({
   variant = 'normal',
   inputDivProps = { style: { display: 'flex' } },
   tabIndex = 0,
-  hiddenErrorText,
+  hiddenErrorText = '',
   hiddenErrorTextProps,
 }: FormInputProps) => {
   const { validity, onValueChange } = useValidationOnChange(validation, value);
@@ -216,40 +216,36 @@ export const FormInput = ({
 
   const ErrorMessage = () => {
     if (isStaticMessageValid()) {
-      return hiddenErrorText ? (
+      return (
         <p
-          {...{
-            ...errorProps,
-            role: Roles.alert,
-          }}
-        >
-          <span {...hiddenErrorTextProps}>{hiddenErrorText}</span>{' '}
-          {staticErrorMessage}
-        </p>
-      ) : (
-        <div
           {...{
             ...errorProps,
             className: classNames(['dcx-error-message', errorProps?.className]),
             role: Roles.alert,
           }}
         >
+          {!isEmpty(hiddenErrorText) && (
+            <span {...hiddenErrorTextProps}>{hiddenErrorText + ' '}</span>
+          )}
           {staticErrorMessage}
-        </div>
+        </p>
       );
     }
 
     if (validity && !validity.valid && showError) {
       return (
-        <div
+        <p
           {...{
             ...errorProps,
             className: classNames(['dcx-error-message', errorProps?.className]),
             role: Roles.alert,
           }}
         >
+          {!isEmpty(hiddenErrorText) && (
+            <span {...hiddenErrorTextProps}>{hiddenErrorText + ' '}</span>
+          )}
           {validity.message}
-        </div>
+        </p>
       );
     }
 

--- a/src/formInput/__tests__/FormInput.test.tsx
+++ b/src/formInput/__tests__/FormInput.test.tsx
@@ -373,6 +373,35 @@ describe('FormInput', () => {
     );
   });
 
+  it('should display the formInput error static message with a visually hidden with no error props', async () => {
+    const { container } = render(
+      <FormInput
+        containerClassName="container"
+        label="label"
+        name="name"
+        type="text"
+        inputClassName="inputClass"
+        inputProps={{
+          defaultValue: 'default value',
+        }}
+        hint={{
+          position: 'above',
+          text: 'hint',
+          className: 'hint-class',
+        }}
+        hiddenErrorText="Error:"
+        hiddenErrorTextProps={{ className: 'visually-hidden' }}
+        staticErrorMessage="we have a problem"
+        errorPosition={ErrorPosition.AFTER_LABEL}
+        containerClassNameError=""
+      />
+    );
+
+    expect(container.querySelector('[role=alert]')?.innerHTML).toBe(
+      '<span class="visually-hidden">Error:</span> we have a problem'
+    );
+  });
+
   it('should not render the formInput with an alert', () => {
     const { container } = render(
       <FormInput

--- a/src/formInput/__tests__/FormInput.test.tsx
+++ b/src/formInput/__tests__/FormInput.test.tsx
@@ -10,6 +10,9 @@ const DummyComponent = ({
   variant = 'normal',
   suffix,
   prefix,
+  errProp = {
+    'data-testid': 'error-container',
+  },
 }: any) => {
   const [value, setValue] = React.useState('');
   const [isValid, setValid] = React.useState<boolean | string>('');
@@ -29,9 +32,7 @@ const DummyComponent = ({
         onChange={handleInputChange}
         isValid={handleValidity}
         displayError={displayError}
-        errorProps={{
-          'data-testid': 'error-container',
-        }}
+        errorProps={errProp}
         variant={variant}
         suffix={suffix}
         prefix={prefix}
@@ -45,6 +46,7 @@ const DummyComponent = ({
           },
           message: 'is invalid',
         }}
+        staticErrorMessage={undefined}
       />
       <label data-testid="check-validity">{isValid.toString()}</label>
     </>
@@ -71,7 +73,7 @@ const DummyComponentTriggerError = () => {
         displayError={displayError}
         errorPosition={ErrorPosition.BOTTOM}
         errorProps={{
-          'data-testid': 'error-container',
+          id: 'error-container',
         }}
         validation={{
           rule: {
@@ -309,6 +311,36 @@ describe('FormInput', () => {
     expect(placeholder).toBeTruthy();
   });
 
+  it('should display the formInput error static message', async () => {
+    const { container } = render(
+      <FormInput
+        containerClassName="container"
+        label="label"
+        name="name"
+        type="text"
+        inputClassName="inputClass"
+        inputProps={{
+          defaultValue: 'default value',
+        }}
+        hint={{
+          position: 'above',
+          text: 'hint',
+          className: 'hint-class',
+        }}
+        errorProps={{
+          className: '',
+        }}
+        staticErrorMessage="we have a problem"
+        errorPosition={ErrorPosition.AFTER_LABEL}
+        containerClassNameError=""
+      />
+    );
+
+    expect(container.querySelector('[role=alert]')?.innerHTML).toBe(
+      'we have a problem'
+    );
+  });
+
   it('should not render the formInput with an alert', () => {
     const { container } = render(
       <FormInput
@@ -390,19 +422,19 @@ describe('FormInput', () => {
     const input = screen.getByRole('textbox');
     await user.type(input, 'TEST VALUE');
     let error: any;
-    if (container.firstChild && container.firstChild.firstChild)
-      error = container.firstChild.firstChild.childNodes[0];
+    if (container.firstChild) error = container.firstChild.childNodes[0];
     expect(error.innerHTML).toBe('is invalid');
   });
 
   it('should display the formInput error message on the bottom', async () => {
     const user = userEvent.setup();
-    const { container } = render(<DummyComponent pos={ErrorPosition.BOTTOM} />);
+    const { container } = render(
+      <DummyComponent pos={ErrorPosition.BOTTOM} errProp={null} />
+    );
     const input = screen.getByRole('textbox');
     await user.type(input, 'TEST VALUE');
     let error: any;
-    if (container.firstChild && container.firstChild.lastChild)
-      error = container.firstChild.lastChild.childNodes[0];
+    if (container.firstChild) error = container.firstChild.lastChild;
     expect(error.innerHTML).toBe('is invalid');
   });
 

--- a/src/formInput/__tests__/FormInput.test.tsx
+++ b/src/formInput/__tests__/FormInput.test.tsx
@@ -341,6 +341,38 @@ describe('FormInput', () => {
     );
   });
 
+  it('should display the formInput error static message with a visually hidden', async () => {
+    const { container } = render(
+      <FormInput
+        containerClassName="container"
+        label="label"
+        name="name"
+        type="text"
+        inputClassName="inputClass"
+        inputProps={{
+          defaultValue: 'default value',
+        }}
+        hint={{
+          position: 'above',
+          text: 'hint',
+          className: 'hint-class',
+        }}
+        errorProps={{
+          className: '',
+        }}
+        hiddenErrorText="Error:"
+        hiddenErrorTextProps={{ className: 'visually-hidden' }}
+        staticErrorMessage="we have a problem"
+        errorPosition={ErrorPosition.AFTER_LABEL}
+        containerClassNameError=""
+      />
+    );
+
+    expect(container.querySelector('[role=alert]')?.innerHTML).toBe(
+      '<span class="visually-hidden">Error:</span> we have a problem'
+    );
+  });
+
   it('should not render the formInput with an alert', () => {
     const { container } = render(
       <FormInput

--- a/src/formInput/__tests__/FormInput.test.tsx
+++ b/src/formInput/__tests__/FormInput.test.tsx
@@ -13,6 +13,7 @@ const DummyComponent = ({
   errProp = {
     'data-testid': 'error-container',
   },
+  hiddenErrorText,
 }: any) => {
   const [value, setValue] = React.useState('');
   const [isValid, setValid] = React.useState<boolean | string>('');
@@ -47,6 +48,7 @@ const DummyComponent = ({
           message: 'is invalid',
         }}
         staticErrorMessage={undefined}
+        hiddenErrorText={hiddenErrorText}
       />
       <label data-testid="check-validity">{isValid.toString()}</label>
     </>
@@ -86,6 +88,7 @@ const DummyComponentTriggerError = () => {
           message: 'is invalid',
         }}
         containerClassNameError="error-container"
+        hiddenErrorText=""
       />
       <button onClick={handleClick}>submit</button>
     </>
@@ -105,6 +108,7 @@ const DummyStaticComponent = ({ pos, hint }: any) => (
       containerClassName="container-class"
       containerClassNameError="container-error"
       hint={hint}
+      hiddenErrorText=""
     />
   </>
 );
@@ -121,6 +125,7 @@ describe('FormInput', () => {
         inputProps={{
           placeholder: 'enter your email',
         }}
+        hiddenErrorText=""
       />
     );
     expect(screen.getByRole('textbox')).toBeInTheDocument();
@@ -142,6 +147,7 @@ describe('FormInput', () => {
           },
           content: 'prefix',
         }}
+        hiddenErrorText=""
       />
     );
     const input: any = screen.getByRole('textbox');
@@ -159,6 +165,7 @@ describe('FormInput', () => {
         value="@_-bddcd6A"
         ariaLabel="input-label"
         ariaRequired={true}
+        hiddenErrorText=""
       />
     );
     const input: any = screen.getByRole('textbox');
@@ -182,6 +189,7 @@ describe('FormInput', () => {
           },
           content: 'prefix',
         }}
+        hiddenErrorText=""
       />
     );
     const input: any = screen.getByRole('textbox');
@@ -205,6 +213,7 @@ describe('FormInput', () => {
           },
           content: 'prefix',
         }}
+        hiddenErrorText=""
       />
     );
     const inputContainer: Element | null =
@@ -236,6 +245,7 @@ describe('FormInput', () => {
         inputProps={{
           id: 'password',
         }}
+        hiddenErrorText=""
       />
     );
 
@@ -258,6 +268,7 @@ describe('FormInput', () => {
           },
           content: 'prefix',
         }}
+        hiddenErrorText=""
       />
     );
     expect(container.querySelector('#prefix')).toBeInTheDocument();
@@ -280,6 +291,7 @@ describe('FormInput', () => {
           },
           content: 'suffix',
         }}
+        hiddenErrorText=""
       />
     );
     expect(container.querySelector('#suffix')).toBeInTheDocument();
@@ -304,6 +316,7 @@ describe('FormInput', () => {
           className: 'label-class-name',
           htmlFor: 'input-id',
         }}
+        hiddenErrorText=""
       />
     );
     const placeholder = container.querySelector('.dcx-form-input--placeholder');
@@ -333,6 +346,7 @@ describe('FormInput', () => {
         staticErrorMessage="we have a problem"
         errorPosition={ErrorPosition.AFTER_LABEL}
         containerClassNameError=""
+        hiddenErrorText=""
       />
     );
 
@@ -369,7 +383,7 @@ describe('FormInput', () => {
     );
 
     expect(container.querySelector('[role=alert]')?.innerHTML).toBe(
-      '<span class="visually-hidden">Error:</span> we have a problem'
+      '<span class="visually-hidden">Error: </span>we have a problem'
     );
   });
 
@@ -398,7 +412,7 @@ describe('FormInput', () => {
     );
 
     expect(container.querySelector('[role=alert]')?.innerHTML).toBe(
-      '<span class="visually-hidden">Error:</span> we have a problem'
+      '<span class="visually-hidden">Error: </span>we have a problem'
     );
   });
 
@@ -425,6 +439,7 @@ describe('FormInput', () => {
         staticErrorMessage={}
         errorPosition={ErrorPosition.AFTER_LABEL}
         containerClassNameError=""
+        hiddenErrorText=""
       />
     );
 
@@ -453,6 +468,7 @@ describe('FormInput', () => {
         staticErrorMessage=""
         errorPosition={ErrorPosition.AFTER_LABEL}
         containerClassNameError=""
+        hiddenErrorText=""
       />
     );
 
@@ -478,25 +494,48 @@ describe('FormInput', () => {
   it('should display the formInput error message on top', async () => {
     const user = userEvent.setup();
     const { container } = render(
-      <DummyComponent pos={ErrorPosition.BEFORE_LABEL} />
+      <DummyComponent
+        pos={ErrorPosition.BEFORE_LABEL}
+        hiddenErrorText="Error:"
+      />
     );
     const input = screen.getByRole('textbox');
     await user.type(input, 'TEST VALUE');
     let error: any;
     if (container.firstChild) error = container.firstChild.childNodes[0];
-    expect(error.innerHTML).toBe('is invalid');
+    expect(error.innerHTML).toBe('<span>Error: </span>is invalid');
   });
 
   it('should display the formInput error message on the bottom', async () => {
     const user = userEvent.setup();
     const { container } = render(
-      <DummyComponent pos={ErrorPosition.BOTTOM} errProp={null} />
+      <DummyComponent
+        pos={ErrorPosition.BOTTOM}
+        errProp={null}
+        hiddenErrorText="Error:"
+      />
     );
     const input = screen.getByRole('textbox');
     await user.type(input, 'TEST VALUE');
     let error: any;
     if (container.firstChild) error = container.firstChild.lastChild;
-    expect(error.innerHTML).toBe('is invalid');
+    expect(error.innerHTML).toBe('<span>Error: </span>is invalid');
+  });
+
+  it('should display the formInput error message on the bottom with a span', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <DummyComponent
+        pos={ErrorPosition.BOTTOM}
+        errProp={null}
+        hiddenErrorText={'Error:'}
+      />
+    );
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'TEST VALUE');
+    let error: any;
+    if (container.firstChild) error = container.firstChild.lastChild;
+    expect(error.innerHTML).toBe('<span>Error: </span>is invalid');
   });
 
   it('should return validation false on startup if the validation rules are not met', async () => {
@@ -685,6 +724,7 @@ describe('FormInput', () => {
           },
           content: 'prefix',
         }}
+        hiddenErrorText=""
       />
     );
     const input = screen.getByRole('textbox');
@@ -692,14 +732,24 @@ describe('FormInput', () => {
   });
 
   it('should have a 0 tabIndex value by default', () => {
-    render(<FormInput name="password" type="text" value="test" />);
+    render(
+      <FormInput name="password" type="text" value="test" hiddenErrorText="" />
+    );
 
     const input: any = screen.getByRole('textbox');
     expect(input.getAttribute('tabindex')).toBe('0');
   });
 
   it('should accept tabIndex attribute', () => {
-    render(<FormInput name="password" type="text" value="test" tabIndex={1} />);
+    render(
+      <FormInput
+        name="password"
+        type="text"
+        value="test"
+        tabIndex={1}
+        hiddenErrorText=""
+      />
+    );
 
     const input: any = screen.getByRole('textbox');
     expect(input.getAttribute('tabindex')).toBe('1');

--- a/stories/FormInput/ClassBased.stories.js
+++ b/stories/FormInput/ClassBased.stories.js
@@ -209,6 +209,8 @@ export const StaticError = {
     staticErrorMessage: 'some error appened here',
     errorPosition: 'after-hint',
     containerClassNameError: 'govuk-form-group--error',
+    hiddenErrorText: 'Error:',
+    hiddenErrorTextProps: { className: 'govuk-visually-hidden' },
   },
 };
 

--- a/stories/FormInput/ClassBased.stories.js
+++ b/stories/FormInput/ClassBased.stories.js
@@ -243,9 +243,6 @@ export const Error = {
       },
       message: 'Enter an event name',
     },
-    errorMessage: {
-      className: 'govuk-error-message',
-    },
     errorPosition: 'before-label',
     ariaLabel: 'standard-input-validation',
     ariaRequired: 'true',

--- a/stories/FormInput/Documentation.mdx
+++ b/stories/FormInput/Documentation.mdx
@@ -81,6 +81,8 @@ An example with all the available properties is:
   containerClassNameError="containerClassNameError"
   tabIndex={0}
   variant="floating"
+  hiddenErrorText="Error:"
+  hiddenErrorTextProps={{ className: 'visually-hidden' }}
 />
 ```
 

--- a/stories/FormInput/design-system/AccessibleTheme.stories.js
+++ b/stories/FormInput/design-system/AccessibleTheme.stories.js
@@ -210,6 +210,7 @@ export const StaticError = {
     },
     staticErrorMessage: 'some error appened here',
     errorPosition: 'after-hint',
+    hiddenErrorText: 'Error:',
   },
   argTypes: { onChange: { action: 'onChange' } },
 };
@@ -231,6 +232,7 @@ export const StaticErrorBottom = {
     },
     staticErrorMessage: 'some error appened here',
     errorPosition: 'bottom',
+    hiddenErrorText: 'Error:',
   },
 };
 
@@ -251,6 +253,7 @@ export const StaticErrorBottomHint = {
     },
     staticErrorMessage: 'some error appened here',
     errorPosition: 'bottom',
+    hiddenErrorText: 'Error:',
   },
 };
 
@@ -283,6 +286,7 @@ export const StaticErrorBottomHintAbove = {
     },
     staticErrorMessage: 'some error appened here',
     errorPosition: 'after-label',
+    hiddenErrorText: 'Error:',
   },
 };
 

--- a/stories/FormInput/design-system/DarkTheme.stories.js
+++ b/stories/FormInput/design-system/DarkTheme.stories.js
@@ -281,6 +281,7 @@ export const StaticError = {
     },
     staticErrorMessage: 'some error appened here',
     errorPosition: 'after-hint',
+    hiddenErrorText: 'Error:',
   },
   argTypes: { onChange: { action: 'onChange' } },
 };
@@ -311,6 +312,7 @@ export const StaticErrorBottom = {
     },
     staticErrorMessage: 'some error appened here',
     errorPosition: 'bottom',
+    hiddenErrorText: 'Error:',
   },
 };
 
@@ -340,6 +342,7 @@ export const StaticErrorBottomHint = {
     },
     staticErrorMessage: 'some error appened here',
     errorPosition: 'bottom',
+    hiddenErrorText: 'Error:',
   },
 };
 
@@ -381,5 +384,6 @@ export const StaticErrorBottomHintAbove = {
     },
     staticErrorMessage: 'some error appened here',
     errorPosition: 'after-label',
+    hiddenErrorText: 'Error:',
   },
 };

--- a/stories/FormInput/design-system/Default.stories.js
+++ b/stories/FormInput/design-system/Default.stories.js
@@ -179,6 +179,7 @@ export const StaticError = {
     },
     staticErrorMessage: 'some error appened here',
     errorPosition: 'after-hint',
+    hiddenErrorText: 'Error:',
   },
   argTypes: { onChange: { action: 'onChange' } },
 };
@@ -200,6 +201,7 @@ export const StaticErrorBottom = {
     },
     staticErrorMessage: 'some error appened here',
     errorPosition: 'bottom',
+    hiddenErrorText: 'Error:',
   },
 };
 
@@ -220,6 +222,7 @@ export const StaticErrorBottomHint = {
     },
     staticErrorMessage: 'some error appened here',
     errorPosition: 'bottom',
+    hiddenErrorText: 'Error:',
   },
 };
 
@@ -252,6 +255,7 @@ export const StaticErrorBottomHintAbove = {
     },
     staticErrorMessage: 'some error appened here',
     errorPosition: 'after-label',
+    hiddenErrorText: 'Error:',
   },
 };
 

--- a/stories/FormInput/design-system/FloatingTheme.stories.js
+++ b/stories/FormInput/design-system/FloatingTheme.stories.js
@@ -209,6 +209,7 @@ export const StaticError = {
     ariaLabel: 'input-with-error',
     ariaRequired: 'true',
     staticErrorMessage: 'some error appened here',
+    hiddenErrorText: 'Error:',
     errorPosition: 'bottom',
   },
   argTypes: { onChange: { action: 'onChange' } },
@@ -232,6 +233,7 @@ export const StaticErrorHint = {
       id: 'id_hint',
     },
     staticErrorMessage: 'some error appened here',
+    hiddenErrorText: 'Error:',
     errorPosition: 'bottom',
   },
 };
@@ -254,6 +256,7 @@ export const StaticErrorBottomHint = {
       id: 'id_hint',
     },
     staticErrorMessage: 'some error appened here',
+    hiddenErrorText: 'Error:',
     errorPosition: 'bottom',
   },
 };
@@ -288,6 +291,7 @@ export const StaticErrorBottomHintAbove = {
       id: 'id_hint',
     },
     staticErrorMessage: 'some error appened here',
+    hiddenErrorText: 'Error:',
     errorPosition: 'after-label',
   },
 };

--- a/stories/FormInput/design-system/MaterialTheme.stories.js
+++ b/stories/FormInput/design-system/MaterialTheme.stories.js
@@ -237,6 +237,7 @@ export const StaticError = {
     ariaLabel: 'input-with-error',
     ariaRequired: 'true',
     staticErrorMessage: 'some error appened here',
+    hiddenErrorText: 'Error:',
     errorPosition: 'bottom',
   },
   argTypes: { onChange: { action: 'onChange' } },
@@ -260,6 +261,7 @@ export const StaticErrorHint = {
       id: 'id_hint',
     },
     staticErrorMessage: 'some error appened here',
+    hiddenErrorText: 'Error:',
     errorPosition: 'bottom',
   },
 };
@@ -282,6 +284,7 @@ export const StaticErrorBottomHint = {
       id: 'id_hint',
     },
     staticErrorMessage: 'some error appened here',
+    hiddenErrorText: 'Error:',
     errorPosition: 'bottom',
   },
 };
@@ -316,6 +319,7 @@ export const StaticErrorBottomHintAbove = {
       id: 'id_hint',
     },
     staticErrorMessage: 'some error appened here',
+    hiddenErrorText: 'Error:',
     errorPosition: 'after-label',
   },
 };

--- a/stories/liveEdit/FormInputLive.tsx
+++ b/stories/liveEdit/FormInputLive.tsx
@@ -62,6 +62,8 @@ function FormInputDemo() {
         }}
         tabIndex={0}
         variant="floating"
+        hiddenErrorText="Error:"
+        hiddenErrorTextProps={{ className: 'visually-hidden' }}
     />
   )
 }

--- a/stories/liveEdit/FormInputLive.tsx
+++ b/stories/liveEdit/FormInputLive.tsx
@@ -46,13 +46,19 @@ function FormInputDemo() {
             message:
             'your password need to be min 8 chars 1 Uppercase, 1 Number and one special character',
         }}
-        errorMessage={{}}
+        staticErrorMessage='this is a static error message'
         errorPosition="bottom"
         prefix={{
-          content: <></>
+          properties: {
+            id: 'prefix',
+          },
+          content: 'prefix',
         }}
         suffix={{
-          content: <></>
+          properties: {
+            id: 'suffix',
+          },
+          content: 'suffix',
         }}
         tabIndex={0}
         variant="floating"


### PR DESCRIPTION
When rendering the form input I noticed the empty error div was still rendered on page load

```html
<div class="dcx-form-input govuk-form-group">
   <label for="userReference">some label</label>
   <div class="dcx-error-message"></div> <!-- this container div is not required -->
   <div class="dcx-hint govuk-hint">some hint</div>
   <input name="userReference" type="text" class="govuk-input" tabindex="0" id="userReference" value="">
</div>
```
![Screenshot 2024-04-19 at 13 53 38](https://github.com/Capgemini/dcx-react-library/assets/11960286/7d82cfea-58d0-492b-a673-40eb1be26f97)

This PR remove this such that the error div containing the error message is rendered only when needed