### PR TITLE
fix: removing label as default aria-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **A11y**
 
 - [Tab - Adding keyboard event listeners](https://github.com/Capgemini/dcx-react-library/issues/658)
+- [Button - removing label as default aria-label](https://github.com/Capgemini/dcx-react-library/issues/663)
 
 ## 1.0.0 (15/04/2024)
 

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -92,7 +92,7 @@ export const Button = ({
   onClick,
   type = BUTTON_TYPE.BUTTON,
   disabled = false,
-  ariaLabel = `${label}`,
+  ariaLabel,
   disableClickForMs,
   customPrefixImg,
   customPostfixImg,

--- a/src/button/__tests__/Button.test.tsx
+++ b/src/button/__tests__/Button.test.tsx
@@ -304,11 +304,11 @@ describe('Button', () => {
     );
   });
 
-  it('should default the aria-label to the label attribute if not defined', () => {
+  it('should not default the aria-label to the label attribute if not defined', () => {
     const handleClick = jest.fn();
     render(<Button onClick={handleClick} label="Register" />);
     const button: any = screen.getByRole('button');
-    expect(button.getAttribute('aria-label')).toBe('Register');
+    expect(button.getAttribute('aria-label')).toBeNull();
   });
 
   it('should render the provided aria-label if the attribute is defined', () => {

--- a/stories/changelog.mdx
+++ b/stories/changelog.mdx
@@ -9,6 +9,7 @@ import { Meta } from '@storybook/blocks';
 **A11y**
 
 - [Tab - Adding keyboard event listeners](https://github.com/Capgemini/dcx-react-library/issues/658)
+- [Button - removing label as default aria-label](https://github.com/Capgemini/dcx-react-library/issues/663)
 
 ## 1.0.0 (15/04/2024)
 


### PR DESCRIPTION
This change simply removes `label` as a default `aria-label` on the button component to avoid having an aria label which conflicts with the visible label, which may have hidden text for screen readers to read.