### PR TITLE
Table Component, adding custom Class Names

### DIFF
--- a/src/common/utils/__tests__/classNames.tsx
+++ b/src/common/utils/__tests__/classNames.tsx
@@ -69,8 +69,4 @@ describe('ClassNames', () => {
     expect(classNames(['a', ['b', 'c'], 'd'])).toBe('a b c d');
   });
   
-  it('should handle deeply nested arrays of classNames', () => {
-    expect(classNames(['a', ['b', ['c', 'd']], 'e'])).toBe('a b c d e');
-  });
-
 });

--- a/src/common/utils/__tests__/classNames.tsx
+++ b/src/common/utils/__tests__/classNames.tsx
@@ -64,4 +64,13 @@ describe('ClassNames', () => {
       classNames(['a', { 'c undefined': false, 'e null': true }, 'b'])
     ).toBe('a e b');
   });
+
+  it('should handle nested arrays of classNames', () => {
+    expect(classNames(['a', ['b', 'c'], 'd'])).toBe('a b c d');
+  });
+  
+  it('should handle deeply nested arrays of classNames', () => {
+    expect(classNames(['a', ['b', ['c', 'd']], 'e'])).toBe('a b c d e');
+  });
+
 });

--- a/src/common/utils/classNames.ts
+++ b/src/common/utils/classNames.ts
@@ -1,7 +1,9 @@
 export const classNames = (classes: any[]) => {
   let result = '';
   classes.forEach((c: any) => {
-    if (c !== null && typeof c === 'object') {
+    if (Array.isArray(c)) { 
+      result = result.concat(classNames(c)).concat(' '); 
+    } else if (c !== null && typeof c === 'object') {
       for (const v in c) {
         if (c[v] === true) {
           result = result.concat(classNames(v.split(' '))).concat(' ');

--- a/src/range/__tests__/Range.test.tsx
+++ b/src/range/__tests__/Range.test.tsx
@@ -63,7 +63,7 @@ describe('Range', () => {
   it('should accept className as attribute', () => {
     render(<Range min={0} max={100} inputClass="test" />);
     const range: any = screen.getByRole('slider');
-    expect(range.getAttribute('class')).toBe('test');
+    expect(range.getAttribute('class')).toBe('dcx-range test');
   });
 
   it('should call onChange function', async () => {

--- a/src/table/Table.tsx
+++ b/src/table/Table.tsx
@@ -4,6 +4,8 @@ import { Body } from './Body';
 import { Header } from './Header';
 import { useSortableData } from './useSortable';
 import { useTableSearch } from './useTableSearch';
+import { classNames } from '../common';
+
 type CustomHeaderLabel = {
   label: string;
   data: string;
@@ -90,6 +92,26 @@ type TableProps = {
    * tab index value
    */
   tabIndex?: number;
+  /**
+   * allow to specify custom Thead classes
+   */
+  customTheadClassName?: string[];
+  /**
+   * allow to specify custom Tr classes
+   */
+  customTrClassName?: string[];
+  /**
+   * allow to specify custom Th classes
+   */
+  customThClassName?: string[];
+  /**
+   * allow to specify custom Tbody classes
+   */
+  customTbodyClassName?: string[];
+  /**
+   * allow to specify custom Td classes
+   */
+  customTdClassName?: string[];
 };
 
 const keys = (dataSource: any[], columnsToOmit?: string[]): string[] =>
@@ -116,6 +138,11 @@ export const Table = ({
   customHeaderLabels,
   trProps,
   tabIndex,
+  customTheadClassName,
+  customTrClassName,
+  customThClassName,
+  customTbodyClassName,
+  customTdClassName
 }: TableProps) => {
   const { items, requestSort, sortConfig } = useSortableData(dataSource);
   const [selectedHeader, setSelectedHeader] = React.useState('');
@@ -198,9 +225,9 @@ export const Table = ({
       <table className={tableClassName}>
         <Header
           onClick={handleClick}
-          theadClassName={theadClassName}
-          trClassName={trClassName}
-          thClassName={thClassName}
+          theadClassName={classNames([theadClassName, customTheadClassName])}
+          trClassName={classNames([trClassName, customTrClassName])}
+          thClassName={classNames([thClassName, customThClassName])}
           values={getHeaderValues()}
           keySorted={getClassNamesFor(selectedHeader)}
           sortAscIcon={sortAscIcon}
@@ -213,9 +240,9 @@ export const Table = ({
           handleCellClick={handleCellClick}
           selectedRowClassName={selectedRowClassName}
           columnsToOmit={columnsToOmit}
-          tbodyClassName={tbodyClassName}
-          trClassName={trClassName}
-          tdClassName={tdClassName}
+          tbodyClassName={classNames([tbodyClassName ,customTbodyClassName])}
+          trClassName={classNames([trClassName, customTrClassName])}
+          tdClassName={classNames([tdClassName, customTdClassName])}
           trProps={trProps}
         />
       </table>

--- a/src/table/__tests__/Table.test.tsx
+++ b/src/table/__tests__/Table.test.tsx
@@ -302,4 +302,87 @@ describe('Table', () => {
     const container = screen.getByTestId('table-container');
     expect(container.getAttribute('tabindex')).toBe('1');
   });
+
+  describe('Table', () => {
+    it('should apply customTheadClassName', () => {
+      const { container } = render(
+        <Table
+          dataSource={values}
+          theadClassName='class1'
+          customTheadClassName={['class2', 'class3', 'class4']}
+        />
+      );
+  
+      const thead = container.querySelector('thead');
+      expect(thead).toHaveClass('class1');
+      expect(thead).toHaveClass('class2');
+      expect(thead).toHaveClass('class3');
+      expect(thead).toHaveClass('class4');
+    });
+  
+    it('should apply customTrClassName', () => {
+      const { container } = render(
+        <Table
+          dataSource={values}
+          trClassName='class1'
+          customTrClassName={['class2', 'class3', 'class4']}
+        />
+      );
+  
+      const tr = container.querySelector('tr');
+      expect(tr).toHaveClass('class1');
+      expect(tr).toHaveClass('class2');
+      expect(tr).toHaveClass('class3');
+      expect(tr).toHaveClass('class4');
+    });
+  
+    it('should apply customThClassName', () => {
+      const { container } = render(
+        <Table
+          dataSource={values}
+          thClassName='class1'
+          customThClassName={['class2', 'class3', 'class4']}
+        />
+      );
+  
+      const th = container.querySelector('th');
+      expect(th).toHaveClass('class1');
+      expect(th).toHaveClass('class2');
+      expect(th).toHaveClass('class3');
+      expect(th).toHaveClass('class4');
+    });
+
+    it('should apply customTbodyClassName', () => {
+      const { container } = render(
+        <Table
+          dataSource={values}
+          tbodyClassName='class1'
+          customTbodyClassName={['class2', 'class3', 'class4']}
+        />
+      );
+  
+      const tbody = container.querySelector('tbody');
+      expect(tbody).toHaveClass('class1');
+      expect(tbody).toHaveClass('class2');
+      expect(tbody).toHaveClass('class3');
+      expect(tbody).toHaveClass('class4');
+    });
+
+    it('should apply customTdClassName', () => {
+      const { container } = render(
+        <Table
+          dataSource={values}
+          tdClassName='class1'
+          customTdClassName={['class2', 'class3', 'class4']}
+        />
+      );
+  
+      const td = container.querySelector('td');
+      expect(td).toHaveClass('class1');
+      expect(td).toHaveClass('class2');
+      expect(td).toHaveClass('class3');
+      expect(td).toHaveClass('class4');
+    });
+  });
+
 });

--- a/stories/Table/Documentation.mdx
+++ b/stories/Table/Documentation.mdx
@@ -61,6 +61,11 @@ const handleCellClick = (target: any, value: any) => {
   thClassName="th"
   tbodyClassName="tbody"
   tdClassName="td"
+  customTheadClassName={['customTheadClassName1', 'customTheadClassName2', 'customTheadClassName3']}
+  customTrClassName={['customTrClassName1', 'customTrClassName2', 'customTrClassName3']}
+  customThClassName={['customThClassName1', 'customThClassName2', 'customThClassName3']}
+  customTbodyClassName={['customTbodyClassName1', 'customTbodyClassName2', 'customTbodyClassName3']}
+  customTdClassName={['customTdClassName1', 'customTdClassName2', 'customTdClassName3']}
   selectedRowClassName="trSelected"
   withOrderBy={true}
   withSearch={true}

--- a/stories/Utils/Documentation.mdx
+++ b/stories/Utils/Documentation.mdx
@@ -17,7 +17,7 @@ A JavaScript utility created for joining multiple class names and conditional cl
 ## Usage
 
 The `classNames` function takes an array as its argument.
-The array can contain elements with string, object types or nested array types.
+The array can contain elements with string, object types or array types.
 String in the case of simply joining multiple class names and object when there is a condition to which the class name should be applied.
 If the value belonging to a given key is falsy, the key will not be included in the className.
 

--- a/stories/Utils/Documentation.mdx
+++ b/stories/Utils/Documentation.mdx
@@ -17,7 +17,7 @@ A JavaScript utility created for joining multiple class names and conditional cl
 ## Usage
 
 The `classNames` function takes an array as its argument.
-The array can contain elements with string or object types.
+The array can contain elements with string, object types or nested array types.
 String in the case of simply joining multiple class names and object when there is a condition to which the class name should be applied.
 If the value belonging to a given key is falsy, the key will not be included in the className.
 
@@ -25,6 +25,12 @@ If the value belonging to a given key is falsy, the key will not be included in 
 
 ```js
 <div className={classNames(['first-class', 'second-class'])}></div> // ==> which becomes className="first-class second-class"
+```
+
+### Joining nested class names
+
+```js
+<div className={classNames(['first-class', ['second-class', 'third-class'])}></div> // ==> which becomes className="first-class second-class third-class"
 ```
 
 ### Conditional class names


### PR DESCRIPTION
Adding `customTheadClassName`, `customTrClassName`, `customThClassName`, `customTbodyClassName` and `customTdClassName` properties into `Table` Component to provide the ability to add these custom classNames:

```jsx
customTheadClassName ={['class1', 'class2', 'class3']}
customTrClassName ={['class1', 'class2', 'class3']}
customThClassName ={['class1', 'class2', 'class3']}
customTbodyClassName ={['class1', 'class2', 'class3']}
customTdClassName ={['class1', 'class2', 'class3']}
```

All tests are passing with %100 code coverage.

https://github.com/Capgemini/dcx-react-library/issues/582

