### PR TITLE
Fix/fix random failure test

### DIFF
--- a/src/button/__tests__/Button.test.tsx
+++ b/src/button/__tests__/Button.test.tsx
@@ -16,7 +16,7 @@ const DummyLoadingButton = ({ loadingLabel }: any) => {
 
   const handleClick = () => {
     setIsLoading(true);
-    setTimeout(() => setIsLoading(false), 1000);
+    setTimeout(() => setIsLoading(false), 900);
   };
 
   return (


### PR DESCRIPTION
Test failure:
![image](https://github.com/user-attachments/assets/b479708b-c465-41d3-bbc6-92143c118b80)

After fix:
![image](https://github.com/user-attachments/assets/8286b0ab-f805-46ec-838e-2150ec362238)
![image](https://github.com/user-attachments/assets/3615ca1a-e271-453e-85f7-07f3577693dc)


The issue was happening due to race condition between the onClick handler (which set the isLoading (disabled) status to false after 1000 ms) and the waitFor method (which also have a default timeout of 1000ms). Instead of increasing the waitFor timeout for all of the use cases, I have decreased the onClick handler's timeout to 900ms.